### PR TITLE
Fine tuning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # wikipediapreview-wordpress
-WordPress plugin for Wikipedia Preview
+This WordPress plugin is a thin wrapper around (Wikipedia Preview)[wikimedia/wikipedia-preview] to simplify its integration and usage within WordPress.
 
 ## Run the plugin locally
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,24 +2,26 @@
 Contributors: wikimediafoundation
 Donate link: https://donate.wikimedia.org/wiki/Ways_to_Give
 Tags: wikipedia, facts, popup, card, wiki
-Stable tag: trunk
+Stable tag: 1.0.0
 License: MIT
 License URI: https://github.com/wikimedia/wikipedia-preview/blob/main/LICENSE
 
 Wikipedia Preview allows you to show a popup card with a short summary from Wikipedia when a reader clicks or hovers over a link
 
 == Description ==
-Wikipedia Preview is a plugin that brings free knowledge to your site in the form of an Wikipedia article preview popup. Your readers will be able to simply click or hover over a word and directly see a short summary from the linked Wikipedia article. Wikipedia Preview is an official plugin developed and supported by the Wikimedia Foundation.  
+Wikipedia Preview is a plugin that brings free knowledge to your site in the form of an Wikipedia article preview popup. Your readers will be able to simply click or hover over a word and directly see a short summary from the linked Wikipedia article. Wikipedia Preview is an official plugin developed and supported by the Wikimedia Foundation.
+
+This plugin complies with the Wikimedia Foundation (privacy policy)[https://foundation.wikimedia.org/wiki/Privacy_policy].
 
 **Features**
 
 * Handles any link to a Wikipedia article regardless of language, lead image presence or length
 * Works for Right-to-Left (RTL) and Left-To-Right (LTR) languages
-* A built-in gallery to dive into article images. 
+* A built-in gallery to dive into article images.
 
 **How to use**
 
-As a site owner, after you (download and install)[https://wordpress.org/support/article/managing-plugins/#finding-and-installing-plugins] the Wikipedia Preview plugin, you can simply (add a link)[https://wordpress.com/support/links/] in your site content to any Wikipedia artile URL. 
+As a site owner, after you (download and install)[https://wordpress.org/support/article/managing-plugins/#finding-and-installing-plugins] the Wikipedia Preview plugin, you can simply (add a link)[https://wordpress.com/support/links/] in your site content to any Wikipedia article URL and it will be turned into a preview.
 
 == Screenshots ==
 

--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -13,18 +13,18 @@
  */
 function wikipediapreview_enqueue_scripts() {
     $assets_dir = plugin_dir_url( __FILE__ ) . 'assets/';
-    
+
     wp_enqueue_script(
-        'wikipedia-preview', $assets_dir . 'js/wikipedia-preview.production.js', [], false, true 
+        'wikipedia-preview', $assets_dir . 'js/wikipedia-preview.production.js', [], false, true
     );
 
-    wp_enqueue_script( 
-        'wikipedia-preview-init', $assets_dir . 'js/init.js', [], false, true 
-    );	
+    wp_enqueue_script(
+        'wikipedia-preview-init', $assets_dir . 'js/init.js', [], false, true
+    );
 }
 
-// record the option of detect links feature enabled in this version,
-// detect links feature may disable by default in the next version
+// Record the option of detect links feature enabled in this version,
+// detect links feature may be disabled by default in the next version
 function wikipediapreview_detect_true() {
     add_option( 'wikipediapreview_options_detect_links', true );
 }


### PR DESCRIPTION
- Rename the main plugin file so it doesn't contain "WordPress" (that's not really allowed). When released, the plugin dir will also be just "wikipediapreview" so they will match.
- Add link to privacy policy
- Link to Wikipedia Preview from the readme
- Small wording changes here and there
- Use the version number for the future stable tag. Trunk is not recommended.