### PR TITLE
Force rm during zip process

### DIFF
--- a/scripts/zip.sh
+++ b/scripts/zip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm wikipediapreview.zip
+rm -f wikipediapreview.zip
 zip -r wikipediapreview.zip \
 	wikipediapreview.php \
 	assets \


### PR DESCRIPTION
It shows silent error here while zip isn't existed, therefore adding force step.

![image](https://user-images.githubusercontent.com/2560096/119664174-5e526600-be33-11eb-87b5-87284d8db291.png)
