### PR TITLE
In some site `entry-content` wasn't found, fallback to document

### DIFF
--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -1,4 +1,4 @@
 wikipediaPreview.init( {
-	root: document.querySelector( '.entry-content' ),
+	root: document.querySelector( '.entry-content' ) || document,
 	detectLinks: true,
 } );

--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -1,4 +1,4 @@
 wikipediaPreview.init( {
-	root: document.querySelector( '.entry-content' ) || document,
+	root: document,
 	detectLinks: true,
 } );


### PR DESCRIPTION
how many difference of the content container class name? can it be defined by site owner? or it depends on the theme? check that and confirm before submit the pr to review