### PR TITLE
T279549: First step towards localization

### DIFF
--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -3,8 +3,9 @@
  * Plugin Name: Wikipedia Preview
  * Plugin URI: https://github.com/wikimedia/wikipedia-preview
  * Description: Wikipedia Preview allows you to show a popup card with a short summary from Wikipedia when a reader clicks or hovers over a link
+ * Text Domain: wikipedia-preview
  * Version: 1.0.4
- * Requires at least: 4.2
+ * Requires at least: 4.6
  * Requires PHP: 5.6.39
  * Author: Wikimedia Foundation
  * Author URI: https://wikimediafoundation.org/


### PR DESCRIPTION
https://phabricator.wikimedia.org/T279549

According to what I gathered from research, this is the first step towards enabling localization in our plugin. This is how I'm arriving at this conclusion:

* Header update:
  * Adding text domain as our slug, this is technically optional but says there's no harm including so I suggest we include it just in case
  * Updating to 4.6 is main change, this is the only thing I see we are missing.
  * https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains
* The domain path can be omitted if the plugin is in the official WordPress Plugin Directory.
* Do we need to update anything to readme.txt?
  * Research says no https://wordpress.stackexchange.com/questions/274140/how-does-gettext-works-for-translating-readme-file-of-plugin

What I'm understanding from the docs is that this change is enough for all of the content in our readme.txt to get translated (via WordPress translation process, https://translate.wordpress.org/). That is, the content that's presented in https://wordpress.org/plugins/wikipedia-preview/ is what gets translated, this is the only actual plugin content that we currently have that can be translated. Thing is we can't really test this other than by pushing to the SVN, as far as I can tell. 

All of this being said, check out this commit from a seperate POC branch that resulted from my research: https://github.com/wikimedia/wikipediapreview-wordpress/commit/b2d4843909f68fc9e1d3789e0dd667ed3fcd501a. It's just a rough draft to demonstrate how we can use the `__()` internationalization method inside JS, this is what we could eventually set up labels ("Add", "Remove", etc) for internationalization in the plugin.

Take https://wordpress.org/plugins/wordpress-seo/ for example. If you add a language code to the url (es.wordpress.org/plugins...) you will see the content translated. The WordPress version in [their plugin header](https://plugins.trac.wordpress.org/browser/wordpress-seo/trunk/wp-seo.php?desc=1) satisfies the 4.6 minimum requirement, and they also have `/languages` directory and load text domain and other stuff. Remains to be seen how much of that we will need in our simpler plugin. 

What I expect from merging and pushing this commit is that messages like [this](https://translate.wordpress.org/projects/wp-plugins/wikipedia-preview/) [1] go away, that https://es.wordpress.org/plugins/wikipedia-preview/ will eventually display content in Spanish for example, that we also see message like this [2] in our plugin page letting users know that the content is available in other languages. 

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/4752599/127554125-20e1f7dc-ac6a-4d4a-943a-a56b8b1f2f40.png">



---

_Other resources_

* https://wordpress.stackexchange.com/questions/80334/how-to-make-a-wordpress-plugin-translation-ready
* from the very first commit it’s always been 4.2 https://github.com/wikimedia/wikipediapreview-wordpress/commit/8c0491ca2cad7dd96ff19057f0fab71f00897d2a#diff-f7e6f79077da23af0608a0fc32a068ee63f645cc303e1701db3dfb783d69fef0
* https://translate.wordpress.org/projects/wp-plugins/wikipedia-preview/
