### PR TITLE
T286941: Tested up to WordPress version 5.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wikimediafoundation
 Donate link: https://donate.wikimedia.org/wiki/Ways_to_Give
 Tags: wikipedia, facts, popup, card, wiki
 Stable tag: 1.0.6
-Tested up to: 5.7
+Tested up to: 5.8
 License: MIT
 License URI: https://github.com/wikimedia/wikipedia-preview/blob/main/LICENSE
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T286941

The WordPress version can be updated from the Dashboard as instructed [here](https://wordpress.org/support/article/updating-wordpress/#one-click-update). Look for the installed version confirmation from either the Dashboard [1] or Local app [2]. 

I tested by creating new separate blog post for both the non-gutenberg version (concerns present PR) and the upcoming gutenberg version (for the future). I followed the regular user flow to create/add Wikipedia Preview to the blog content, tested the preview correctly displaying in Chrome and Firefox. Everything seems to be working fine. 


<img width="835" alt="image" src="https://user-images.githubusercontent.com/4752599/128213638-824e7aff-61a7-4e5f-a2de-71018c23aa30.png">


--- 

_Resources_

https://wordpress.org/support/wordpress-version/version-5-8/
https://make.wordpress.org/core/2021/06/29/block-based-widgets-editor-in-wordpress-5-8/
https://core.trac.wordpress.org/milestone/5.8
https://wordpress.org/support/article/updating-wordpress/
https://browsehappy.com/
 