### PR TITLE
Enqueue the gutenburg custom tools on posts and pages only.

### DIFF
--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -58,6 +58,9 @@ function wikipediapreview_detect_deletion() {
 }
 
 function wikipediapreview_guten_enqueue() {
+	if ( !in_array( get_post_type(), array( 'post', 'page' ) ) ) {
+		return;
+	}
 	$build_dir       = plugin_dir_url( __FILE__ ) . 'build/';
 	$libs_dir        = plugin_dir_url( __FILE__ ) . 'libs/';
 	$media_type_all  = 'all';

--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -58,7 +58,7 @@ function wikipediapreview_detect_deletion() {
 }
 
 function wikipediapreview_guten_enqueue() {
-	if ( !in_array( get_post_type(), array( 'post', 'page' ) ) ) {
+	if ( ! in_array( get_post_type(), array( 'post', 'page' ), true ) ) {
 		return;
 	}
 	$build_dir       = plugin_dir_url( __FILE__ ) . 'build/';


### PR DESCRIPTION
The widget editor is using Gutenburg so the 'enqueue_block_editor_assets' action runs but it is not appropriate to include the custom format or post meta.

https://phabricator.wikimedia.org/T292634