### PR TITLE
Fix notice appearing in 404.php template

### DIFF
--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -39,10 +39,12 @@ function wikipediapreview_enqueue_scripts() {
 	);
 
 	global $post;
-	$options = array(
-		'detectLinks' => get_post_meta( $post->ID, 'wikipediapreview_detectlinks', true ),
-	);
-	wp_localize_script( 'wikipedia-preview-init', 'wikipediapreview_init_options', $options );
+	if ( isset( $post->ID ) ) {
+		$options = array(
+			'detectLinks' => get_post_meta( $post->ID, 'wikipediapreview_detectlinks', true ),
+		);
+		wp_localize_script( 'wikipedia-preview-init', 'wikipediapreview_init_options', $options );
+	}
 
 	wp_enqueue_style(
 		'wikipedia-preview-link-style',


### PR DESCRIPTION
Tested on Twenty Twenty One bundled theme.
When in the context of a 404 page, a notice appears since `$post->ID` is not defined.
This PR fixes the issue.

Before patch: screenshot of the notice appearing on 404.php
<img width="1400" alt="Capture d’écran 2021-10-11 à 22 54 32" src="https://user-images.githubusercontent.com/1590998/136855431-c48dfdf4-6cb4-4e28-894c-923425a686d6.png">