### PR TITLE
T293306 Uncaught TypeError with fulltextSearch (api.js)

### DIFF
--- a/src/link/api.js
+++ b/src/link/api.js
@@ -62,13 +62,13 @@ export const fulltextSearch = ( lang, term, callback ) => {
 			const { search, pages } = data.query;
 			callback(
 				Object.values( search ).map( ( item ) => {
-					const page =
-						pages &&
-						pages.find( ( { pageid } ) => pageid === item.pageid );
+					const page = pages?.find(
+						( { pageid } ) => pageid === item.pageid
+					);
 					return {
 						title: item.title,
 						description: stripHtml( item.snippet ),
-						thumbnail: page.thumbnail?.source,
+						thumbnail: page?.thumbnail?.source,
 					};
 				} )
 			);


### PR DESCRIPTION
Phabricator: https://phabricator.wikimedia.org/T293306

The fulltext doesn't always return the `pages` object