### PR TITLE
Styling update

### DIFF
--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -235,7 +235,7 @@
 				background-image: url(./images/close-language.svg);
 				width: 20px;
 				height: 20px;
-				cursor: pointer;	
+				cursor: pointer;
 			}
 		}
 


### PR DESCRIPTION
Phabricator: https://phabricator.wikimedia.org/T294404

 - [x] Change .wikipediapreview-edit-inline-search-label color from #3c434a to #202122.
 - [ ] Change search bar border color from #007cba to #3366cc. This would be applicable for Language switcher search bar too.
 - [x] Align search bar by setting following margin values for .wikipediapreview-edit-inline-search-input. margin: 30px 10px 30px;
 - [ ] Change .components-popover_content border color from #ccc to #A2A9B1.
 - [ ] Change .components-text-control__input border color from #757575 to #A2A9B1.
 - [x] Change Place holder text "Search Wikipedia" color to 72777D.
