### PR TITLE
T287146: language selector follow up

### DIFF
--- a/src/link/inline.js
+++ b/src/link/inline.js
@@ -79,118 +79,132 @@ export const InlineEditUI = ( {
 			noArrow={ false }
 			expandOnMobile={ true }
 		>
-			{ !languageSelector && (
+			{ ! languageSelector ? (
+				<div>
 					<div className="wikipediapreview-edit-inline-search">
-					<p className="wikipediapreview-edit-inline-search-label">
-						<span>
-							{ __( 'Wikipedia Preview', 'wikipedia-preview' ) }
-						</span>
-						&nbsp;
-						<span className="wikipediapreview-edit-inline-search-label-beta">
-							{ __( 'beta', 'wikipedia-preview' ) }
-						</span>
-					</p>
-					<TextControl
-						className={ `wikipediapreview-edit-inline-search-input ${
-							langCodeAdjustment ? 'lang-code-adjustment' : ''
-						}` }
-						value={ title }
-						onChange={ setTitle }
-						onFocus={ () => setFocused( true ) }
-						onBlur={ () => setFocused( false ) }
-						placeholder={ __(
-							'Search Wikipedia',
-							'wikipedia-preview'
-						) }
-					/>
-					<div className="wikipediapreview-edit-inline-search-icon" />
-					<div className="wikipediapreview-edit-inline-search-tools">
-						{ title && (
-							<Button
-								onClick={ () => {
-									setTitle( '' );
-								} }
-								className="wikipediapreview-edit-inline-search-close"
-							/>
-						) }
-						<div
-							className={ `wikipediapreview-edit-inline-search-language 
+						<p className="wikipediapreview-edit-inline-search-label">
+							<span>
+								{ __(
+									'Wikipedia Preview',
+									'wikipedia-preview'
+								) }
+							</span>
+							&nbsp;
+							<span className="wikipediapreview-edit-inline-search-label-beta">
+								{ __( 'beta', 'wikipedia-preview' ) }
+							</span>
+						</p>
+						<TextControl
+							className={ `wikipediapreview-edit-inline-search-input ${
+								langCodeAdjustment ? 'lang-code-adjustment' : ''
+							}` }
+							value={ title }
+							onChange={ setTitle }
+							onFocus={ () => setFocused( true ) }
+							onBlur={ () => setFocused( false ) }
+							placeholder={ __(
+								'Search Wikipedia',
+								'wikipedia-preview'
+							) }
+						/>
+						<div className="wikipediapreview-edit-inline-search-icon" />
+						<div className="wikipediapreview-edit-inline-search-tools">
+							{ title && (
+								<Button
+									onClick={ () => {
+										setTitle( '' );
+									} }
+									className="wikipediapreview-edit-inline-search-close"
+								/>
+							) }
+							<div
+								className={ `wikipediapreview-edit-inline-search-language 
 							${ focused ? `focused` : '' }` }
-							onClick={ () => setLanguageSelector( true ) }
-							role="presentation"
-						>
-							<div
-								className={ `wikipediapreview-edit-inline-search-language-code ${
-									focused ? `focused` : ''
-								}` }
-							>
-								{ lang }
-							</div>
-							<div className="wikipediapreview-edit-inline-search-language-dropdown"></div>
-						</div>
-					</div>
-					{ loading && (
-						<div className="wikipediapreview-edit-inline-search-loading"></div>
-					) }
-				</div>
-			) }
-			{ loading && ! searchList.length && (
-				<div className="wikipediapreview-edit-inline-info">
-					<bdi>
-						{ __( 'Loading search results…', 'wikipedia-preview' ) }
-					</bdi>
-				</div>
-			) }
-			{ ! loading && title && ! searchList.length && ! languageSelector && (
-				<div className="wikipediapreview-edit-inline-info">
-					<bdi>{ __( 'No results found', 'wikipedia-preview' ) }</bdi>
-				</div>
-			) }
-			{ ! languageSelector && searchList && searchList.length ? (
-				<div className="wikipediapreview-edit-inline-list">
-					{ searchList.map( ( item, index ) => {
-						return (
-							<div
-								className={ `wikipediapreview-edit-inline-list-item ${
-									index === hoveredIndex ? 'hovered' : ''
-								}` }
-								key={ item.title }
-								role="link"
-								tabIndex={ index }
-								onClick={ () => {
-									onApply( value, item.title, lang );
-								} }
-								onKeyUp={ () => {
-									onApply( value, item.title, lang );
-								} }
+								onClick={ () => setLanguageSelector( true ) }
+								role="presentation"
 							>
 								<div
-									className="wikipediapreview-edit-inline-list-item-img"
-									style={
-										item.thumbnail
-											? {
-													backgroundImage: `url(${ item.thumbnail })`,
-											  }
-											: {}
-									}
-								/>
-								<span className="wikipediapreview-edit-inline-list-item-title">
-									{ item.title }
-								</span>
-								<span className="wikipediapreview-edit-inline-list-item-description">
-									{ item.description }
-								</span>
+									className={ `wikipediapreview-edit-inline-search-language-code ${
+										focused ? `focused` : ''
+									}` }
+								>
+									{ lang }
+								</div>
+								<div className="wikipediapreview-edit-inline-search-language-dropdown"></div>
 							</div>
-						);
-					} ) }
+						</div>
+						{ loading && (
+							<div className="wikipediapreview-edit-inline-search-loading"></div>
+						) }
+					</div>
+					{ loading && ! searchList.length && (
+						<div className="wikipediapreview-edit-inline-info">
+							<bdi>
+								{ __(
+									'Loading search results…',
+									'wikipedia-preview'
+								) }
+							</bdi>
+						</div>
+					) }
+					{ ! loading && title && ! searchList.length && (
+						<div className="wikipediapreview-edit-inline-info">
+							<bdi>
+								{ __(
+									'No results found',
+									'wikipedia-preview'
+								) }
+							</bdi>
+						</div>
+					) }
+					{ searchList && searchList.length ? (
+						<div className="wikipediapreview-edit-inline-list">
+							{ searchList.map( ( item, index ) => {
+								return (
+									<div
+										className={ `wikipediapreview-edit-inline-list-item ${
+											index === hoveredIndex
+												? 'hovered'
+												: ''
+										}` }
+										key={ item.title }
+										role="link"
+										tabIndex={ index }
+										onClick={ () => {
+											onApply( value, item.title, lang );
+										} }
+										onKeyUp={ () => {
+											onApply( value, item.title, lang );
+										} }
+									>
+										<div
+											className="wikipediapreview-edit-inline-list-item-img"
+											style={
+												item.thumbnail
+													? {
+															backgroundImage: `url(${ item.thumbnail })`,
+													  }
+													: {}
+											}
+										/>
+										<span className="wikipediapreview-edit-inline-list-item-title">
+											{ item.title }
+										</span>
+										<span className="wikipediapreview-edit-inline-list-item-description">
+											{ item.description }
+										</span>
+									</div>
+								);
+							} ) }
+						</div>
+					) : null }
 				</div>
-			) : null }
-			{ languageSelector ? (
+			) : (
 				<LanguageSelector
 					setLanguageSelector={ setLanguageSelector }
 					setLang={ setLang }
 				/>
-			) : null }
+			) }
 			<KeyboardShortcuts
 				bindGlobal={ true }
 				shortcuts={ {

--- a/src/link/inline.js
+++ b/src/link/inline.js
@@ -106,6 +106,7 @@ export const InlineEditUI = ( {
 								'Search Wikipedia',
 								'wikipedia-preview'
 							) }
+							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 						<div className="wikipediapreview-edit-inline-search-icon" />
 						<div className="wikipediapreview-edit-inline-search-tools">

--- a/src/link/inline.js
+++ b/src/link/inline.js
@@ -79,59 +79,61 @@ export const InlineEditUI = ( {
 			noArrow={ false }
 			expandOnMobile={ true }
 		>
-			<div className="wikipediapreview-edit-inline-search">
-				<p className="wikipediapreview-edit-inline-search-label">
-					<span>
-						{ __( 'Wikipedia Preview', 'wikipedia-preview' ) }
-					</span>
-					&nbsp;
-					<span className="wikipediapreview-edit-inline-search-label-beta">
-						{ __( 'beta', 'wikipedia-preview' ) }
-					</span>
-				</p>
-				<TextControl
-					className={ `wikipediapreview-edit-inline-search-input ${
-						langCodeAdjustment ? 'lang-code-adjustment' : ''
-					}` }
-					value={ title }
-					onChange={ setTitle }
-					onFocus={ () => setFocused( true ) }
-					onBlur={ () => setFocused( false ) }
-					placeholder={ __(
-						'Search Wikipedia',
-						'wikipedia-preview'
-					) }
-				/>
-				<div className="wikipediapreview-edit-inline-search-icon" />
-				<div className="wikipediapreview-edit-inline-search-tools">
-					{ title && (
-						<Button
-							onClick={ () => {
-								setTitle( '' );
-							} }
-							className="wikipediapreview-edit-inline-search-close"
-						/>
-					) }
-					<div
-						className={ `wikipediapreview-edit-inline-search-language 
-						${ focused ? `focused` : '' }` }
-						onClick={ () => setLanguageSelector( true ) }
-						role="presentation"
-					>
+			{ !languageSelector && (
+					<div className="wikipediapreview-edit-inline-search">
+					<p className="wikipediapreview-edit-inline-search-label">
+						<span>
+							{ __( 'Wikipedia Preview', 'wikipedia-preview' ) }
+						</span>
+						&nbsp;
+						<span className="wikipediapreview-edit-inline-search-label-beta">
+							{ __( 'beta', 'wikipedia-preview' ) }
+						</span>
+					</p>
+					<TextControl
+						className={ `wikipediapreview-edit-inline-search-input ${
+							langCodeAdjustment ? 'lang-code-adjustment' : ''
+						}` }
+						value={ title }
+						onChange={ setTitle }
+						onFocus={ () => setFocused( true ) }
+						onBlur={ () => setFocused( false ) }
+						placeholder={ __(
+							'Search Wikipedia',
+							'wikipedia-preview'
+						) }
+					/>
+					<div className="wikipediapreview-edit-inline-search-icon" />
+					<div className="wikipediapreview-edit-inline-search-tools">
+						{ title && (
+							<Button
+								onClick={ () => {
+									setTitle( '' );
+								} }
+								className="wikipediapreview-edit-inline-search-close"
+							/>
+						) }
 						<div
-							className={ `wikipediapreview-edit-inline-search-language-code ${
-								focused ? `focused` : ''
-							}` }
+							className={ `wikipediapreview-edit-inline-search-language 
+							${ focused ? `focused` : '' }` }
+							onClick={ () => setLanguageSelector( true ) }
+							role="presentation"
 						>
-							{ lang }
+							<div
+								className={ `wikipediapreview-edit-inline-search-language-code ${
+									focused ? `focused` : ''
+								}` }
+							>
+								{ lang }
+							</div>
+							<div className="wikipediapreview-edit-inline-search-language-dropdown"></div>
 						</div>
-						<div className="wikipediapreview-edit-inline-search-language-dropdown"></div>
 					</div>
+					{ loading && (
+						<div className="wikipediapreview-edit-inline-search-loading"></div>
+					) }
 				</div>
-				{ loading && (
-					<div className="wikipediapreview-edit-inline-search-loading"></div>
-				) }
-			</div>
+			) }
 			{ loading && ! searchList.length && (
 				<div className="wikipediapreview-edit-inline-info">
 					<bdi>

--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -218,9 +218,8 @@
 
 	&-language-selector {
 		position: relative;
-		top: -140px;
-		height: 310px;
-		width: 100%;
+		height: 392px;
+		width: 400px;
 		background: #fff;
 		overflow: hidden;
 		z-index: 1000;


### PR DESCRIPTION
Context here: https://phabricator.wikimedia.org/T287146#7505785

Using the same `languageSelector` state, I realized I could also just switch the main search div on or off, then subsequently realized we could refactor a bit to abstract the `languageSelector` conditional logic to just one instance: within the same inline.js `Popover` we are either showing the language selector UI or the search UI. The benefit of this being that now the dimensions of the language selector can be set without interference. 

This is how I should have done it from the beginning. 



