### PR TITLE
Add localized languages support

### DIFF
--- a/src/link/inline.js
+++ b/src/link/inline.js
@@ -187,6 +187,7 @@ export const InlineEditUI = ( {
 				<LanguageSelector
 					setLanguageSelector={ setLanguageSelector }
 					setLang={ setLang }
+					lang={ lang }
 				/>
 			) : null }
 			<KeyboardShortcuts

--- a/src/link/language-selector.js
+++ b/src/link/language-selector.js
@@ -1,98 +1,12 @@
 import { TextControl, KeyboardShortcuts } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { getLanguages } from '@wikimedia/language-data';
-import { isLanguageWithWiki, defaultLanguages } from './languages';
+import { filterLanguages, defaultFilter } from './languages';
 
 export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 	const [ value, setValue ] = useState( '' );
 	const [ items, setItems ] = useState( [] );
 	const [ hoveredIndex, setHoverIndex ] = useState( -1 );
-	const limit = defaultLanguages.length;
-	const languages = getLanguages();
-
-	const normalize = ( result, language ) => {
-		if ( isLanguageWithWiki( language ) ) {
-			result.push( {
-				name: languages[ language ][ 2 ],
-				code: language,
-			} );
-		} else if ( language === 'en-simple' ) {
-			result.push( {
-				name: languages[ language ][ 2 ],
-				code: 'simple',
-			} );
-		}
-		return result;
-	};
-
-	const getLocalized = ( language ) => {
-		const localizedName = new Intl.DisplayNames( [ lang ], {
-			type: 'language',
-		} );
-		const invalid = [
-			'bat-smg',
-			'be-x-old',
-			'cbk-zam',
-			'fiu-vro',
-			'map-bms',
-			'roa-rup',
-			'zh-classical',
-			'zh-min-nan',
-			'zh-yue',
-			'zh-cdo',
-		];
-
-		if ( invalid.indexOf( language ) === -1 ) {
-			return localizedName.of( language ).toLowerCase();
-		}
-		return false;
-	};
-
-	const filterLanguages = ( target ) => {
-		setValue( target );
-		const targetLang = target.toLowerCase().trim();
-
-		if ( targetLang === '' ) {
-			setItems( defaultFilter() );
-			return;
-		}
-
-		const filtered = Object.keys( languages )
-			.filter( ( language ) => {
-				const localized =
-					Intl.DisplayNames && getLocalized( language );
-				if ( languages[ language ].length > 2 ) {
-					return (
-						languages[ language ][ 2 ]
-							.toLowerCase()
-							.indexOf( targetLang ) !== -1 ||
-						language.indexOf( targetLang ) !== -1 ||
-						( localized && localized.indexOf( targetLang ) !== -1 )
-					);
-				}
-				return false;
-			} )
-			.reduce(
-				( result, language ) => normalize( result, language ),
-				[]
-			);
-
-		setItems( filtered.slice( 0, limit ) );
-	};
-
-	const defaultFilter = () => {
-		const filtered = Object.keys( languages )
-			.filter( ( language ) => {
-				return defaultLanguages.indexOf( language ) !== -1;
-			} )
-			.reduce(
-				( result, language ) => normalize( result, language ),
-				[]
-			);
-
-		return filtered;
-	};
 
 	const selectLanguage = ( languageCode ) => {
 		setLang( languageCode );
@@ -116,7 +30,9 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 			<TextControl
 				className="wikipediapreview-edit-inline-language-selector-input"
 				value={ value }
-				onChange={ filterLanguages }
+				onChange={ ( target ) => {
+					filterLanguages( target, lang, setValue, setItems );
+				} }
 				placeholder={ __( 'Search languages', 'wikipedia-preview' ) }
 				autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 			/>

--- a/src/link/language-selector.js
+++ b/src/link/language-selector.js
@@ -31,7 +31,8 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 				className="wikipediapreview-edit-inline-language-selector-input"
 				value={ value }
 				onChange={ ( target ) => {
-					filterLanguages( target, lang, setValue, setItems );
+					setValue( target );
+					setItems( filterLanguages( target, lang ) );
 				} }
 				placeholder={ __( 'Search languages', 'wikipedia-preview' ) }
 				autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus

--- a/src/link/language-selector.js
+++ b/src/link/language-selector.js
@@ -7,7 +7,6 @@ import { isLanguageWithWiki, defaultLanguages } from './languages';
 export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 	const [ value, setValue ] = useState( '' );
 	const [ items, setItems ] = useState( [] );
-	const [ displayNamesSupport, setDisplayNamesSupport ] = useState( false );
 	const [ hoveredIndex, setHoverIndex ] = useState( -1 );
 	const limit = defaultLanguages.length;
 	const languages = getLanguages();
@@ -62,7 +61,7 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 		const filtered = Object.keys( languages )
 			.filter( ( language ) => {
 				const localized =
-					displayNamesSupport && getLocalized( language );
+					Intl.DisplayNames && getLocalized( language );
 				if ( languages[ language ].length > 2 ) {
 					return (
 						languages[ language ][ 2 ]
@@ -102,7 +101,6 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 
 	useEffect( () => {
 		setItems( defaultFilter() );
-		setDisplayNamesSupport( !! Intl.DisplayNames );
 	}, [] );
 
 	return (

--- a/src/link/language-selector.js
+++ b/src/link/language-selector.js
@@ -31,8 +31,23 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 		const localizedName = new Intl.DisplayNames( [ lang ], {
 			type: 'language',
 		} );
+		const invalid = [
+			'bat-smg',
+			'be-x-old',
+			'cbk-zam',
+			'fiu-vro',
+			'map-bms',
+			'roa-rup',
+			'zh-classical',
+			'zh-min-nan',
+			'zh-yue',
+			'zh-cdo',
+		];
 
-		return localizedName.of( language ).toLowerCase();
+		if ( invalid.indexOf( language ) === -1 ) {
+			return localizedName.of( language ).toLowerCase();
+		}
+		return false;
 	};
 
 	const filterLanguages = ( target ) => {
@@ -47,15 +62,13 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 		const filtered = Object.keys( languages )
 			.filter( ( language ) => {
 				const localized =
-					language.indexOf( '-' ) === -1 &&
-					displayNamesSupport &&
-					getLocalized( language );
+					displayNamesSupport && getLocalized( language );
 				if ( languages[ language ].length > 2 ) {
 					return (
 						languages[ language ][ 2 ]
 							.toLowerCase()
 							.indexOf( targetLang ) !== -1 ||
-						language === targetLang ||
+						language.indexOf( targetLang ) !== -1 ||
 						( localized && localized.indexOf( targetLang ) !== -1 )
 					);
 				}

--- a/src/link/language-selector.js
+++ b/src/link/language-selector.js
@@ -28,7 +28,6 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 	};
 
 	const getLocalized = ( language ) => {
-		console.log('getLocalized');
 		const localizedName = new Intl.DisplayNames( [ lang ], {
 			type: 'language',
 		} );
@@ -47,14 +46,17 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 
 		const filtered = Object.keys( languages )
 			.filter( ( language ) => {
-				const localized = language.indexOf('-') === -1 && displayNamesSupport && getLocalized( language );
+				const localized =
+					language.indexOf( '-' ) === -1 &&
+					displayNamesSupport &&
+					getLocalized( language );
 				if ( languages[ language ].length > 2 ) {
 					return (
 						languages[ language ][ 2 ]
 							.toLowerCase()
 							.indexOf( targetLang ) !== -1 ||
 						language === targetLang ||
-						localized && localized.indexOf( targetLang ) !== -1
+						( localized && localized.indexOf( targetLang ) !== -1 )
 					);
 				}
 				return false;
@@ -87,7 +89,7 @@ export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 
 	useEffect( () => {
 		setItems( defaultFilter() );
-		setDisplayNamesSupport( !!Intl.DisplayNames )
+		setDisplayNamesSupport( !! Intl.DisplayNames );
 	}, [] );
 
 	return (

--- a/src/link/language-selector.js
+++ b/src/link/language-selector.js
@@ -4,9 +4,10 @@ import { useState, useEffect } from '@wordpress/element';
 import { getLanguages } from '@wikimedia/language-data';
 import { isLanguageWithWiki, defaultLanguages } from './languages';
 
-export const LanguageSelector = ( { setLanguageSelector, setLang } ) => {
+export const LanguageSelector = ( { setLanguageSelector, setLang, lang } ) => {
 	const [ value, setValue ] = useState( '' );
 	const [ items, setItems ] = useState( [] );
+	const [ displayNamesSupport, setDisplayNamesSupport ] = useState( false );
 	const [ hoveredIndex, setHoverIndex ] = useState( -1 );
 	const limit = defaultLanguages.length;
 	const languages = getLanguages();
@@ -26,6 +27,15 @@ export const LanguageSelector = ( { setLanguageSelector, setLang } ) => {
 		return result;
 	};
 
+	const getLocalized = ( language ) => {
+		console.log('getLocalized');
+		const localizedName = new Intl.DisplayNames( [ lang ], {
+			type: 'language',
+		} );
+
+		return localizedName.of( language ).toLowerCase();
+	};
+
 	const filterLanguages = ( target ) => {
 		setValue( target );
 		const targetLang = target.toLowerCase().trim();
@@ -37,12 +47,14 @@ export const LanguageSelector = ( { setLanguageSelector, setLang } ) => {
 
 		const filtered = Object.keys( languages )
 			.filter( ( language ) => {
+				const localized = language.indexOf('-') === -1 && displayNamesSupport && getLocalized( language );
 				if ( languages[ language ].length > 2 ) {
 					return (
 						languages[ language ][ 2 ]
 							.toLowerCase()
 							.indexOf( targetLang ) !== -1 ||
-						language === targetLang
+						language === targetLang ||
+						localized && localized.indexOf( targetLang ) !== -1
 					);
 				}
 				return false;
@@ -75,6 +87,7 @@ export const LanguageSelector = ( { setLanguageSelector, setLang } ) => {
 
 	useEffect( () => {
 		setItems( defaultFilter() );
+		setDisplayNamesSupport( !!Intl.DisplayNames )
 	}, [] );
 
 	return (

--- a/src/link/languages.js
+++ b/src/link/languages.js
@@ -364,41 +364,40 @@ const normalize = ( result, language ) => {
 };
 
 const getLocalized = ( language, userLang ) => {
-	const localizedName = new Intl.DisplayNames( [ userLang ], {
-		type: 'language',
-	} );
-	const invalid = [
-		'bat-smg',
-		'be-x-old',
-		'cbk-zam',
-		'fiu-vro',
-		'map-bms',
-		'roa-rup',
-		'zh-classical',
-		'zh-min-nan',
-		'zh-yue',
-		'zh-cdo',
-	];
+	if ( Intl.DisplayNames ) {
+		const localizedName = new Intl.DisplayNames( [ userLang ], {
+			type: 'language',
+		} );
+		const invalid = [
+			'bat-smg',
+			'be-x-old',
+			'cbk-zam',
+			'fiu-vro',
+			'map-bms',
+			'roa-rup',
+			'zh-classical',
+			'zh-min-nan',
+			'zh-yue',
+			'zh-cdo',
+		];
 
-	if ( invalid.indexOf( language ) === -1 ) {
-		return localizedName.of( language ).toLowerCase();
+		if ( invalid.indexOf( language ) === -1 ) {
+			return localizedName.of( language ).toLowerCase();
+		}
 	}
 	return false;
 };
 
-export const filterLanguages = ( target, lang, setValue, setItems ) => {
-	setValue( target );
+export const filterLanguages = ( target, lang ) => {
 	const targetLang = target.toLowerCase().trim();
 
 	if ( targetLang === '' ) {
-		setItems( defaultFilter() );
-		return;
+		return defaultFilter();
 	}
 
 	const filtered = Object.keys( languages )
 		.filter( ( language ) => {
-			const localized =
-				Intl.DisplayNames && getLocalized( language, lang );
+			const localized = getLocalized( language, lang );
 			if ( languages[ language ].length > 2 ) {
 				return (
 					languages[ language ][ 2 ]
@@ -412,7 +411,7 @@ export const filterLanguages = ( target, lang, setValue, setItems ) => {
 		} )
 		.reduce( ( result, language ) => normalize( result, language ), [] );
 
-	setItems( filtered.slice( 0, limit ) );
+	return filtered.slice( 0, limit );
 };
 
 export const defaultFilter = () => {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T294392

## Objective

The goal is to allow users to search for langauges using localized strings. That is, if the current user language is english, then typing "hebrew" should render language `he`; if user langauge is spanish, then "hebreo" should render `he`

Is `!! Intl.DisplayNames` an appropriate way to check if the browser supports https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames?

I have tested this in Chrome, Firefox and Safari