### PR TITLE
Fix nagging banner

### DIFF
--- a/banner.php
+++ b/banner.php
@@ -32,7 +32,7 @@ function should_show_banner() {
 		return true;
 	}
 
-	if ( 0 === $value ) {
+	if ( '0' === $value ) {
 		// dismiss forever
 		return false;
 	}


### PR DESCRIPTION
When the user dismisses the review banner, we store the value 0 in the wikipediapreview_banner_dismissed property. However, when we read back the property it has the value '0' so it fails the strict comparison to 0.