### PR TITLE
T329512: Add wordpress class selector

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -3,4 +3,5 @@
 mkdir libs
 cp node_modules/wikipedia-preview/dist/wikipedia-preview.production.js libs/
 cp node_modules/wikipedia-preview/dist/wikipedia-preview-link.css libs/
+echo ".wp-block {}" >> libs/wikipedia-preview-link.css # Needed to allow .wmf-wp-* classes to be available inside Wordpress editor
 npm run build


### PR DESCRIPTION
[T329512](https://phabricator.wikimedia.org/T329512)

Adds `.wp-block` selector directly to wikipedia-preview-link.css so that the stylesheet gets correctly picked up by Wordpress and gets injected inside editor. Context: https://github.com/WordPress/gutenberg/issues/41821. I tested by running `npm install` again and confirm the styling shows up after, please take the time to test as well. 