### PR TITLE
T319542: Remove submenu page so that it is not permanent

### DIFF
--- a/intro.php
+++ b/intro.php
@@ -33,6 +33,8 @@ function wikipediapreview_intro_submenu_page() {
 		'wikipediapreview_intro_submenu_page_callback'
 	);
 	add_action( 'load-' . $submenu, 'wikipediapreview_load_style' );
+	# Remove the submenu right away so that it is not permanent under Settings menu
+	remove_submenu_page('options-general.php', 'wikipediapreview_intro');
 }
 
 function wikipediapreview_load_style() {

--- a/intro.php
+++ b/intro.php
@@ -34,7 +34,7 @@ function wikipediapreview_intro_submenu_page() {
 	);
 	add_action( 'load-' . $submenu, 'wikipediapreview_load_style' );
 	# Remove the submenu right away so that it is not permanent under Settings menu
-	remove_submenu_page('options-general.php', 'wikipediapreview_intro');
+	remove_submenu_page( 'options-general.php', 'wikipediapreview_intro' );
 }
 
 function wikipediapreview_load_style() {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T319542

The idea is that after activating the plugin, the intro page will be shown but it won't be permanent under settings menu.  Tested by deactivating and activating the plugin, with and without the Gutenberg plugin activated. You will notice the intro page url will still exist if you navigate away and the press browser back button.

Let's confirm with Sudhanshu before merging, do we need to add the line "Note: These instructions are specifically applicable to the Gutenberg editor" at the end?

