### PR TITLE
Remove format on target word edit

### DIFF
--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -65,15 +65,15 @@ const Edit = ( {
 					lang,
 				},
 			},
-			0,
-			title.length
+			getTrimmedStart( selectedValue ),
+			getTrimmedEnd( selectedValue )
 		);
 		onChange( insert( value, toInsert ) );
 		onFocus();
 	};
 
 	const updateAttributes = ( selectedValue, title, lang ) => {
-		const newValue = applyFormat( 
+		const newValue = applyFormat(
 			selectedValue,
 			{
 				type: formatType,
@@ -122,24 +122,24 @@ const Edit = ( {
 		return position;
 	};
 
-	const getTrimmedStart = ( value ) => {
-		const selectedString = value.text.slice( value.start, value.end );
+	const getTrimmedStart = ( selectedValue ) => {
+		const selectedString = selectedValue.text.slice( selectedValue.start, selectedValue.end );
 		const trimmed = selectedString.trimStart();
 		if ( selectedString.length !== trimmed.length ) {
 			const delta = selectedString.length - trimmed.length;
-			return value.start + delta;
+			return selectedValue.start + delta;
 		}
-		return value.start;
+		return selectedValue.start;
 	};
 
-	const getTrimmedEnd = ( value ) => {
-		const selectedString = value.text.slice( value.start, value.end );
+	const getTrimmedEnd = ( selectedValue ) => {
+		const selectedString = selectedValue.text.slice( selectedValue.start, selectedValue.end );
 		const trimmed = selectedString.trimEnd();
 		if ( selectedString.length !== trimmed.length ) {
 			const delta = selectedString.length - trimmed.length;
-			return value.end - delta;
+			return selectedValue.end - delta;
 		}
-		return value.end;
+		return selectedValue.end;
 	};
 
 	const handleTextEdit = () => {
@@ -150,7 +150,7 @@ const Edit = ( {
 			const formatEnd = getFormatEnd( value.end + 1 );
 			onChange( removeFormat( value, formatType, formatStart, formatEnd ) );
 		}
-	}
+	};
 
 	useEffect( () => {
 		if ( Object.keys( activeAttributes ).length ) {

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -143,8 +143,17 @@ const Edit = ( {
 	};
 
 	const handleTextEdit = () => {
-		const editDetected = lastValue.formats.length !== value.formats.length;
-		const involvesPreviewFormat = lastValue.formats[ value.start ] && lastValue.formats[ value.start ][ 0 ].type === formatType;
+		const differentLength = lastValue.formats.length !== value.formats.length;
+		const everyCharEqual = value.formats.every( ( f, i ) => lastValue.text[ i ] === value.text[ i ] );
+		const editDetected = differentLength || !everyCharEqual;
+		// Assuming a Left-To-Right language:
+		// --> cursorDirection > 0 means cursor is moving left
+		// --> cursorDirection < 0 means cursor is moving right
+		const cursorDirection = lastValue.start - value.start;
+		const involvesPreviewFormat = cursorDirection >= 0 ?
+			lastValue.formats[ value.start ] && lastValue.formats[ value.start ][ 0 ].type === formatType :
+			lastValue.formats[ value.end - 1 ] && lastValue.formats[ value.end - 1 ][ 0 ].type === formatType;
+
 		if ( editDetected && involvesPreviewFormat ) {
 			const formatStart = getFormatStart( value.start - 1 );
 			const formatEnd = getFormatEnd( value.end + 1 );

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -44,6 +44,7 @@ const Edit = ( {
 	const [ viewingPreview, setViewingPreview ] = useState( false );
 	const startViewingPreview = () => setViewingPreview( true );
 	const stopViewingPreview = () => setViewingPreview( false );
+	const [ lastValue, setLastValue ] = useState( null );
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -102,6 +103,14 @@ const Edit = ( {
 		}
 	};
 
+	const getFormatStart = ( position ) => {
+		if ( value.formats[ position ] && value.formats[ position ][0].type === formatType ) {
+			return getFormatStart( position - 1);
+		} else {
+			return position;
+		}
+	}
+
 	useEffect( () => {
 		if ( Object.keys( activeAttributes ).length ) {
 			stopAddingPreview();
@@ -110,6 +119,21 @@ const Edit = ( {
 			stopViewingPreview();
 		}
 	}, [ activeAttributes ] );
+
+	useEffect( () => {
+		if ( lastValue === null ) {
+			setLastValue( value );
+		} else if (lastValue !== value ) {
+			const deletionDetected = lastValue.formats.length > value.formats.length;
+			const involvesPreviewFormat = lastValue.formats[ value.start ] && lastValue.formats[ value.start ][0].type === formatType;
+			if ( deletionDetected && involvesPreviewFormat ) {
+				const formatEnd = value.start;
+				const formatStart = getFormatStart( formatEnd - 1 );
+				onChange( removeFormat( value, formatType, formatStart, formatEnd ) );
+			}
+			setLastValue( value );
+		}		
+	}, [ value ] );
 
 	return (
 		<>

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -143,13 +143,11 @@ const Edit = ( {
 	};
 
 	const handleTextEdit = () => {
-		const differentLength = lastValue.formats.length !== value.formats.length;
-		const everyCharEqual = value.formats.every( ( f, i ) => lastValue.text[ i ] === value.text[ i ] );
-		const editDetected = differentLength || ! everyCharEqual;
 		// Assuming a Left-To-Right language:
 		// --> cursorDirection > 0 means cursor is moving left
 		// --> cursorDirection < 0 means cursor is moving right
 		const cursorDirection = lastValue.start - value.start;
+		const editDetected = value.text !== lastValue.text;
 		const involvesPreviewFormat = cursorDirection >= 0
 			? lastValue.formats[ value.start ] && lastValue.formats[ value.start ][ 0 ].type === formatType
 			: lastValue.formats[ value.end - 1 ] && lastValue.formats[ value.end - 1 ][ 0 ].type === formatType;

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -145,14 +145,14 @@ const Edit = ( {
 	const handleTextEdit = () => {
 		const differentLength = lastValue.formats.length !== value.formats.length;
 		const everyCharEqual = value.formats.every( ( f, i ) => lastValue.text[ i ] === value.text[ i ] );
-		const editDetected = differentLength || !everyCharEqual;
+		const editDetected = differentLength || ! everyCharEqual;
 		// Assuming a Left-To-Right language:
 		// --> cursorDirection > 0 means cursor is moving left
 		// --> cursorDirection < 0 means cursor is moving right
 		const cursorDirection = lastValue.start - value.start;
-		const involvesPreviewFormat = cursorDirection >= 0 ?
-			lastValue.formats[ value.start ] && lastValue.formats[ value.start ][ 0 ].type === formatType :
-			lastValue.formats[ value.end - 1 ] && lastValue.formats[ value.end - 1 ][ 0 ].type === formatType;
+		const involvesPreviewFormat = cursorDirection >= 0
+			? lastValue.formats[ value.start ] && lastValue.formats[ value.start ][ 0 ].type === formatType
+			: lastValue.formats[ value.end - 1 ] && lastValue.formats[ value.end - 1 ][ 0 ].type === formatType;
 
 		if ( editDetected && involvesPreviewFormat ) {
 			const formatStart = getFormatStart( value.start - 1 );


### PR DESCRIPTION
https://phabricator.wikimedia.org/T342838

This approach compares `value` with a previous version of itself to detect relevant edits and remove preview format accordingly. Trimming the format placement is preventive: we don't want untrimmed preview formats for the user to fix in the first place. 

