### PR TITLE
Show delete links option only if custom post type supports custom-fields

### DIFF
--- a/src/postmeta/wp-postmeta-detectlinks.js
+++ b/src/postmeta/wp-postmeta-detectlinks.js
@@ -5,6 +5,11 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { ToggleControl, PanelRow } from '@wordpress/components';
 
 const WikipediaPreviewPostMetaDetectLinks = ( { postMeta, setPostMeta } ) => {
+	if ( postMeta === undefined ) {
+		// this is probably a custom post type
+		// without 'custom-fields' support
+		return;
+	}
 	return (
 		<PluginDocumentSettingPanel
 			title={ __( 'Wikipedia Preview', 'wikipedia-preview' ) }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T356880

Add guard clause to only show Wikipedia Preview detect links option for post types that support `custom-fields`. Trying to show it for other post types results in an error.