### PR TITLE
T355399: Correct values for new text to be inserted

### DIFF
--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -66,8 +66,8 @@ const Edit = ( {
 					lang,
 				},
 			},
-			getTrimmedStart( selectedValue ),
-			getTrimmedEnd( selectedValue )
+			0,
+			title.length
 		);
 		onChange( insert( value, toInsert ) );
 		onFocus();


### PR DESCRIPTION
https://phabricator.wikimedia.org/T355399

Looks like I introduced this bug in https://github.com/wikimedia/wikipediapreview-wordpress/pull/90, there's no need to trim there because text is about to be inserted (trimmed)