### PR TITLE
T352298: Add custom tooltip 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
 		"XMLHttpRequest": true
 	},
 	"rules": {
-		"click-events-have-key-events": "off"
+		"click-events-have-key-events": "off",
+		"no-shadow": "off"
 	}
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"selector-class-pattern": null
+	}
+}

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -208,7 +208,7 @@ const Edit = ( {
 				localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount', customTooltipDisplayedCount + 1 );
 			}, 1000 );
 		}
-	}, [] );
+	} );
 
 	return (
 		<>

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -204,13 +204,13 @@ const Edit = ( {
 						title={ formatTitle }
 						isActive={ isActive }
 						onClick={ formatButtonClick }
-						className='wikipediapreview-edit-toolbar-button'
+						className="wikipediapreview-edit-toolbar-button"
 					/>
 				</ToolbarGroup>
 			</BlockControls>
 			{ showCustomTooltip && (
 				<CustomTooltip />
-			)}
+			) }
 			{ addingPreview && (
 				<InlineEditUI
 					contentRef={ contentRef }

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -47,11 +47,11 @@ const Edit = ( {
 	const startViewingPreview = () => setViewingPreview( true );
 	const stopViewingPreview = () => setViewingPreview( false );
 	const [ lastValue, setLastValue ] = useState( null );
-	const [ showCustomTooltip, setShowCustomTooltip ] = useState( false );
-	const customTooltipShowedLimit = 1;
 	const toolbarButtonRef = useRef();
+	const [ displayCustomTooltip, setDisplayCustomTooltip ] = useState( false );
 	// eslint-disable-next-line no-undef
-	const customTooltipShowedNumber = parseInt( localStorage.getItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipShowedNumber' ) ) || 0;
+	const customTooltipDisplayedCount = parseInt( localStorage.getItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount' ) ) || 0;
+	const customTooltipDisplayedLimit = 1;
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -200,11 +200,12 @@ const Edit = ( {
 	}, [ value ] );
 
 	useEffect( () => {
-		if ( customTooltipShowedNumber < customTooltipShowedLimit ) {
+		if ( customTooltipDisplayedCount < customTooltipDisplayedLimit ) {
+			// Wait 1 second and then display tooltip
 			setTimeout( () => {
-				setShowCustomTooltip( true );
+				setDisplayCustomTooltip( true );
 				// eslint-disable-next-line no-undef
-				localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipShowedNumber', customTooltipShowedNumber + 1 );
+				localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount', customTooltipDisplayedCount + 1 );
 			}, 1000 );
 		}
 	}, [] );
@@ -215,7 +216,7 @@ const Edit = ( {
 				<ToolbarGroup>
 					<ToolbarButton
 						icon={ generateWikipediaLogo( isActive ? 'white' : 'black' ) }
-						title={ formatTitle }
+						title={ __( 'Add Wikipedia Preview', 'wikipedia-preview' ) }
 						isActive={ isActive }
 						onClick={ formatButtonClick }
 						className="wikipediapreview-edit-toolbar-button"
@@ -223,10 +224,10 @@ const Edit = ( {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			{ showCustomTooltip && (
+			{ displayCustomTooltip && (
 				<CustomTooltip
 					anchorRef={ toolbarButtonRef }
-					setShowCustomTooltip={ setShowCustomTooltip }
+					setDisplayCustomTooltip={ setDisplayCustomTooltip }
 				/>
 			) }
 			{ addingPreview && (

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -210,6 +210,7 @@ const Edit = ( {
 			</BlockControls>
 			<CustomTooltip
 				anchorRef={ toolbarButtonRef }
+				addingPreview={ addingPreview }
 			/>
 			{ addingPreview && (
 				<InlineEditUI

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import {
@@ -47,7 +47,11 @@ const Edit = ( {
 	const startViewingPreview = () => setViewingPreview( true );
 	const stopViewingPreview = () => setViewingPreview( false );
 	const [ lastValue, setLastValue ] = useState( null );
-	const showCustomTooltip = useState( true );
+	const [ showCustomTooltip, setShowCustomTooltip ] = useState( false );
+	const customTooltipShowedLimit = 1;
+	const toolbarButtonRef = useRef();
+	// eslint-disable-next-line no-undef
+	const customTooltipShowedNumber = parseInt( localStorage.getItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipShowedNumber' ) ) || 0;
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -195,6 +199,16 @@ const Edit = ( {
 		}
 	}, [ value ] );
 
+	useEffect( () => {
+		if ( customTooltipShowedNumber < customTooltipShowedLimit ) {
+			setTimeout( () => {
+				setShowCustomTooltip( true );
+				// eslint-disable-next-line no-undef
+				localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipShowedNumber', customTooltipShowedNumber + 1 );
+			}, 1000 );
+		}
+	}, [] );
+
 	return (
 		<>
 			<BlockControls>
@@ -205,11 +219,15 @@ const Edit = ( {
 						isActive={ isActive }
 						onClick={ formatButtonClick }
 						className="wikipediapreview-edit-toolbar-button"
+						ref={ toolbarButtonRef }
 					/>
 				</ToolbarGroup>
 			</BlockControls>
 			{ showCustomTooltip && (
-				<CustomTooltip />
+				<CustomTooltip
+					anchorRef={ toolbarButtonRef }
+					setShowCustomTooltip={ setShowCustomTooltip }
+				/>
 			) }
 			{ addingPreview && (
 				<InlineEditUI

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -10,6 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InlineEditUI } from './inline';
 import { PreviewEditUI } from './preview';
+import { CustomTooltip } from './tooltip';
 
 const formatType = 'wikipediapreview/link';
 const formatTitle = __( 'Wikipedia Preview', 'wikipedia-preview' );
@@ -46,6 +47,7 @@ const Edit = ( {
 	const startViewingPreview = () => setViewingPreview( true );
 	const stopViewingPreview = () => setViewingPreview( false );
 	const [ lastValue, setLastValue ] = useState( null );
+	const showCustomTooltip = useState( true );
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -202,9 +204,13 @@ const Edit = ( {
 						title={ formatTitle }
 						isActive={ isActive }
 						onClick={ formatButtonClick }
+						className='wikipediapreview-edit-toolbar-button'
 					/>
 				</ToolbarGroup>
 			</BlockControls>
+			{ showCustomTooltip && (
+				<CustomTooltip />
+			)}
 			{ addingPreview && (
 				<InlineEditUI
 					contentRef={ contentRef }

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -10,7 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InlineEditUI } from './inline';
 import { PreviewEditUI } from './preview';
-import { CustomTooltip } from './tooltip';
+import { CustomTooltip, getDisplayedCount, incrementDisplayedCount } from './tooltip';
 
 const formatType = 'wikipediapreview/link';
 const formatTitle = __( 'Wikipedia Preview', 'wikipedia-preview' );
@@ -48,10 +48,9 @@ const Edit = ( {
 	const stopViewingPreview = () => setViewingPreview( false );
 	const [ lastValue, setLastValue ] = useState( null );
 	const toolbarButtonRef = useRef();
-	const [ displayCustomTooltip, setDisplayCustomTooltip ] = useState( false );
-	// eslint-disable-next-line no-undef
-	const customTooltipDisplayedCount = parseInt( localStorage.getItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount' ) ) || 0;
-	const customTooltipDisplayedLimit = 1;
+	const [ displayTooltip, setDisplayTooltip ] = useState( false );
+	const [ localTooltipDisplayedCount, setLocalTooltipDisplayedCount ] = useState( null );
+	const tooltipDisplayedLimit = 2;
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -181,11 +180,10 @@ const Edit = ( {
 		}
 	};
 
-	const waitOneSecThenDisplayCustomTooltip = () => {
+	const waitOneSecThenDisplayTooltip = () => {
 		setTimeout( () => {
-			setDisplayCustomTooltip( true );
-			// eslint-disable-next-line no-undef
-			localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount', customTooltipDisplayedCount + 1 );
+			setDisplayTooltip( true );
+			incrementDisplayedCount();
 		}, 1000 );
 	};
 
@@ -208,11 +206,12 @@ const Edit = ( {
 	}, [ value ] );
 
 	useEffect( () => {
-		if ( customTooltipDisplayedCount < customTooltipDisplayedLimit ) {
-			// Wait 1 second and then display tooltip
-			waitOneSecThenDisplayCustomTooltip();
+		if ( localTooltipDisplayedCount === null ) {
+			getDisplayedCount( setLocalTooltipDisplayedCount );
+		} else if ( localTooltipDisplayedCount < tooltipDisplayedLimit ) {
+			waitOneSecThenDisplayTooltip();
 		}
-	} );
+	}, [ localTooltipDisplayedCount ] );
 
 	return (
 		<>
@@ -228,10 +227,10 @@ const Edit = ( {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			{ displayCustomTooltip && (
+			{ displayTooltip && (
 				<CustomTooltip
 					anchorRef={ toolbarButtonRef }
-					setDisplayCustomTooltip={ setDisplayCustomTooltip }
+					setDisplayTooltip={ setDisplayTooltip }
 				/>
 			) }
 			{ addingPreview && (

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -1,4 +1,4 @@
-/* global wikipediapreview_custom_tooltip */
+/* global wikipediapreviewCustomTooltip */
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
@@ -11,7 +11,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InlineEditUI } from './inline';
 import { PreviewEditUI } from './preview';
-import { CustomTooltip, incrementDisplayedCount } from './tooltip';
+import { CustomTooltip, incrementStoredDisplayedCount } from './tooltip';
 
 const formatType = 'wikipediapreview/link';
 const formatTitle = __( 'Wikipedia Preview', 'wikipedia-preview' );
@@ -50,7 +50,7 @@ const Edit = ( {
 	const [ lastValue, setLastValue ] = useState( null );
 	const toolbarButtonRef = useRef();
 	const [ displayTooltip, setDisplayTooltip ] = useState( false );
-	const tooltipDisplayedLimit = 200;
+	const tooltipDisplayedLimit = 2;
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -184,9 +184,10 @@ const Edit = ( {
 		setTimeout( () => {
 			if ( toolbarButtonRef.current ) {
 				setDisplayTooltip( true );
-				incrementDisplayedCount();
-				/* eslint-disable-next-line camelcase */
-				wikipediapreview_custom_tooltip.tooltipCount = parseInt( wikipediapreview_custom_tooltip.tooltipCount ) + 1;
+				incrementStoredDisplayedCount();
+				// Increment global tooltip count directly as well
+				// to ensure count is up to date in between page reloads
+				wikipediapreviewCustomTooltip.tooltipCount = parseInt( wikipediapreviewCustomTooltip.tooltipCount ) + 1;
 			}
 		}, 1000 );
 	};
@@ -210,8 +211,7 @@ const Edit = ( {
 	}, [ value ] );
 
 	useEffect( () => {
-		/* eslint-disable-next-line camelcase */
-		const tooltipDisplayedCount = parseInt( wikipediapreview_custom_tooltip.tooltipCount );
+		const tooltipDisplayedCount = parseInt( wikipediapreviewCustomTooltip.tooltipCount );
 
 		if ( tooltipDisplayedCount < tooltipDisplayedLimit ) {
 			waitOneSecThenDisplayTooltip();

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -222,7 +222,6 @@ const Edit = ( {
 						title={ __( 'Add Wikipedia Preview', 'wikipedia-preview' ) }
 						isActive={ isActive }
 						onClick={ formatButtonClick }
-						className="wikipediapreview-edit-toolbar-button"
 						ref={ toolbarButtonRef }
 					/>
 				</ToolbarGroup>

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -182,8 +182,10 @@ const Edit = ( {
 
 	const waitOneSecThenDisplayTooltip = () => {
 		setTimeout( () => {
-			setDisplayTooltip( true );
-			incrementDisplayedCount();
+			if ( toolbarButtonRef.current ) {
+				setDisplayTooltip( true );
+				incrementDisplayedCount();
+			}
 		}, 1000 );
 	};
 

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -1,4 +1,3 @@
-/* global wikipediapreviewCustomTooltip */
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
@@ -11,7 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InlineEditUI } from './inline';
 import { PreviewEditUI } from './preview';
-import { CustomTooltip, incrementStoredDisplayedCount } from './tooltip';
+import { CustomTooltip } from './tooltip';
 
 const formatType = 'wikipediapreview/link';
 const formatTitle = __( 'Wikipedia Preview', 'wikipedia-preview' );
@@ -49,8 +48,6 @@ const Edit = ( {
 	const stopViewingPreview = () => setViewingPreview( false );
 	const [ lastValue, setLastValue ] = useState( null );
 	const toolbarButtonRef = useRef();
-	const [ displayTooltip, setDisplayTooltip ] = useState( false );
-	const tooltipDisplayedLimit = 2;
 
 	const formatButtonClick = () => {
 		if ( isActive ) {
@@ -180,18 +177,6 @@ const Edit = ( {
 		}
 	};
 
-	const waitOneSecThenDisplayTooltip = () => {
-		setTimeout( () => {
-			if ( toolbarButtonRef.current ) {
-				setDisplayTooltip( true );
-				incrementStoredDisplayedCount();
-				// Increment global tooltip count directly as well
-				// to ensure count is up to date in between page reloads
-				wikipediapreviewCustomTooltip.tooltipCount = parseInt( wikipediapreviewCustomTooltip.tooltipCount ) + 1;
-			}
-		}, 1000 );
-	};
-
 	useEffect( () => {
 		if ( Object.keys( activeAttributes ).length ) {
 			stopAddingPreview();
@@ -210,14 +195,6 @@ const Edit = ( {
 		}
 	}, [ value ] );
 
-	useEffect( () => {
-		const tooltipDisplayedCount = parseInt( wikipediapreviewCustomTooltip.tooltipCount );
-
-		if ( tooltipDisplayedCount < tooltipDisplayedLimit ) {
-			waitOneSecThenDisplayTooltip();
-		}
-	} );
-
 	return (
 		<>
 			<BlockControls>
@@ -231,12 +208,9 @@ const Edit = ( {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			{ displayTooltip && (
-				<CustomTooltip
-					anchorRef={ toolbarButtonRef }
-					setDisplayTooltip={ setDisplayTooltip }
-				/>
-			) }
+			<CustomTooltip
+				anchorRef={ toolbarButtonRef }
+			/>
 			{ addingPreview && (
 				<InlineEditUI
 					contentRef={ contentRef }

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -181,6 +181,14 @@ const Edit = ( {
 		}
 	};
 
+	const waitOneSecThenDisplayCustomTooltip = () => {
+		setTimeout( () => {
+			setDisplayCustomTooltip( true );
+			// eslint-disable-next-line no-undef
+			localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount', customTooltipDisplayedCount + 1 );
+		}, 1000 );
+	};
+
 	useEffect( () => {
 		if ( Object.keys( activeAttributes ).length ) {
 			stopAddingPreview();
@@ -202,11 +210,7 @@ const Edit = ( {
 	useEffect( () => {
 		if ( customTooltipDisplayedCount < customTooltipDisplayedLimit ) {
 			// Wait 1 second and then display tooltip
-			setTimeout( () => {
-				setDisplayCustomTooltip( true );
-				// eslint-disable-next-line no-undef
-				localStorage.setItem( 'WikipediaPreviewWordpressPlugin-CustomTooltipDisplayedCount', customTooltipDisplayedCount + 1 );
-			}, 1000 );
+			waitOneSecThenDisplayCustomTooltip();
 		}
 	} );
 

--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -301,18 +301,34 @@ body {
 				animation-name: wikipediapreview-edit-inline-loader-expanded;
 			}
 		}
+	}
 
-		&-tooltip {
+	.wikipediapreview-edit-tooltip-popover {
+
+		&-content {
 			width: 190px;
 			height: 40px;
 			background: #36c;
 			color: #fff;
 			display: flex;
 			justify-content: center;
+		}
 
-			&-text {
-				align-self: center;
+		&-text {
+			align-self: center;
+		}
+
+		/* stylelint-disable-next-line selector-class-pattern */
+		.components-popover__arrow {
+
+			&::before {
+				background-color: unset;
 			}
+		}
+
+		/* stylelint-disable-next-line selector-class-pattern */
+		.components-popover__triangle-bg {
+			fill: #36c;
 		}
 	}
 

--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -303,12 +303,16 @@ body {
 		}
 
 		&-tooltip {
-			position: relative;
-			top: 0;
-			left: 0;
 			width: 190px;
-			height: 27px;
-			// background: rgba(0, 0, 0, 0.5);
+			height: 40px;
+			background: #36c;
+			color: #fff;
+			display: flex;
+			justify-content: center;
+
+			&-text {
+				align-self: center;
+			}
 		}
 	}
 

--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -318,7 +318,6 @@ body {
 			align-self: center;
 		}
 
-		/* stylelint-disable-next-line selector-class-pattern */
 		.components-popover__arrow {
 
 			&::before {
@@ -326,7 +325,6 @@ body {
 			}
 		}
 
-		/* stylelint-disable-next-line selector-class-pattern */
 		.components-popover__triangle-bg {
 			fill: #36c;
 		}
@@ -334,7 +332,6 @@ body {
 
 	.wikipediapreview-edit-preview-popover {
 
-		/* stylelint-disable-next-line selector-class-pattern */
 		.components-popover__content {
 			background: unset;
 			border: unset;
@@ -421,7 +418,6 @@ body {
 		&.is-expanded {
 			background-color: rgba(0, 0, 0, 0.7);
 
-			/* stylelint-disable-next-line selector-class-pattern */
 			.components-popover__header {
 				visibility: hidden;
 			}

--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -301,6 +301,15 @@ body {
 				animation-name: wikipediapreview-edit-inline-loader-expanded;
 			}
 		}
+
+		&-tooltip {
+			position: relative;
+			top: 0;
+			left: 0;
+			width: 190px;
+			height: 27px;
+			// background: rgba(0, 0, 0, 0.5);
+		}
 	}
 
 	.wikipediapreview-edit-preview-popover {

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -4,11 +4,12 @@ import { useEffect } from '@wordpress/element';
 
 export const CustomTooltip = ( {
 	anchorRef,
-	setShowCustomTooltip,
+	setDisplayCustomTooltip,
 } ) => {
 	useEffect( () => {
+		// Wait 5 seconds and then hide the tooltip
 		setTimeout( () => {
-			setShowCustomTooltip( false );
+			setDisplayCustomTooltip( false );
 		}, 5000 );
 	}, [] );
 

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -1,40 +1,64 @@
+/* global wikipediapreviewCustomTooltip */
 import { __ } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
-
-export const incrementStoredDisplayedCount = () => {
-	fetch( '/wp-json/wikipediapreview/v1/option/', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-	} );
-};
+import { useEffect, useState } from '@wordpress/element';
 
 export const CustomTooltip = ( {
 	anchorRef,
-	setDisplayTooltip,
 } ) => {
-	useEffect( () => {
-		// Wait 5 seconds and then hide the tooltip
+	const [ displayTooltip, setDisplayTooltip ] = useState( false );
+	const tooltipDisplayedCount = useState( parseInt( wikipediapreviewCustomTooltip.tooltipCount ) )[ 0 ];
+	const tooltipDisplayedLimit = 2;
+
+	const incrementStoredDisplayedCount = () => {
+		fetch( '/wp-json/wikipediapreview/v1/option/', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		} );
+	};
+
+	const waitOneSecThenDisplayTooltip = () => {
+		setTimeout( () => {
+			if ( anchorRef.current ) {
+				setDisplayTooltip( true );
+				incrementStoredDisplayedCount();
+				// Increment global tooltip count directly as well
+				// to ensure count is up to date in between page reloads
+				wikipediapreviewCustomTooltip.tooltipCount = tooltipDisplayedCount + 1;
+				waitFiveSecsThenHideTooltip();
+			}
+		}, 1000 );
+	};
+
+	const waitFiveSecsThenHideTooltip = () => {
 		setTimeout( () => {
 			setDisplayTooltip( false );
 		}, 5000 );
-	} );
+	};
+
+	useEffect( () => {
+		if ( tooltipDisplayedCount < tooltipDisplayedLimit ) {
+			waitOneSecThenDisplayTooltip();
+		}
+	}, [] );
 
 	return (
 		<div>
-			<Popover
-				anchor={ anchorRef.current }
-				placement={ 'top' }
-				noArrow={ false }
-				offset={ 10 }
-				className="wikipediapreview-edit-tooltip-popover"
-			>
-				<div className="wikipediapreview-edit-tooltip-popover-content">
-					<p className="wikipediapreview-edit-tooltip-popover-text">{ __( 'Add Wikipedia Preview' ) }</p>
-				</div>
-			</Popover>
+			{ displayTooltip && (
+				<Popover
+					anchor={ anchorRef.current }
+					placement={ 'top' }
+					noArrow={ false }
+					offset={ 10 }
+					className="wikipediapreview-edit-tooltip-popover"
+				>
+					<div className="wikipediapreview-edit-tooltip-popover-content">
+						<p className="wikipediapreview-edit-tooltip-popover-text">{ __( 'Add Wikipedia Preview' ) }</p>
+					</div>
+				</Popover>
+			) }
 		</div>
 	);
 };

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -28,6 +28,13 @@ export const CustomTooltip = ( {
 		updateStoredProperty( 'duration' );
 	};
 
+
+	const clearTimeouts = () => {
+		timeoutIds.forEach( ( id ) => {
+			clearTimeout( id );
+		} );
+	}
+
 	const waitOneSecThenDisplayTooltip = () => {
 		const oneSecId = setTimeout( () => {
 			if ( anchorRef.current ) {
@@ -58,14 +65,13 @@ export const CustomTooltip = ( {
 	useEffect( () => {
 		// Clear all timeouts when unmounting
 		return () => {
-			timeoutIds.forEach( ( id ) => {
-				clearTimeout( id );
-			} );
+			clearTimeouts();
 		};
 	}, [ timeoutIds ] );
 
 	useEffect( () => {
 		if ( addingPreview ) {
+			clearTimeouts();
 			finishDisplayingTooltip();
 		}
 	}, [ addingPreview ] );

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -5,13 +5,16 @@ import { useEffect, useState } from '@wordpress/element';
 
 export const CustomTooltip = ( {
 	anchorRef,
+	addingPreview,
 } ) => {
 	const [ displayTooltip, setDisplayTooltip ] = useState( false );
+	const [ timeoutIds, setTimeoutIds ] = useState( [] );
+	const tooltipDisplayedFullDuration = useState( parseInt( wikipediapreviewCustomTooltip.tooltipDuration ) )[ 0 ];
 	const tooltipDisplayedCount = useState( parseInt( wikipediapreviewCustomTooltip.tooltipCount ) )[ 0 ];
 	const tooltipDisplayedLimit = 2;
 
-	const incrementStoredDisplayedCount = () => {
-		fetch( '/wp-json/wikipediapreview/v1/option/', {
+	const updateStoredProperty = ( prop ) => {
+		fetch( `/wp-json/wikipediapreview/v1/${ prop }/`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -19,30 +22,53 @@ export const CustomTooltip = ( {
 		} );
 	};
 
+	const finishDisplayingTooltip = () => {
+		setDisplayTooltip( false );
+		wikipediapreviewCustomTooltip.tooltipDuration = 1;
+		updateStoredProperty( 'duration' );
+	};
+
 	const waitOneSecThenDisplayTooltip = () => {
-		setTimeout( () => {
+		const oneSecId = setTimeout( () => {
 			if ( anchorRef.current ) {
 				setDisplayTooltip( true );
-				incrementStoredDisplayedCount();
+				updateStoredProperty( 'count' );
 				// Increment global tooltip count directly as well
 				// to ensure count is up to date in between page reloads
 				wikipediapreviewCustomTooltip.tooltipCount = tooltipDisplayedCount + 1;
 				waitFiveSecsThenHideTooltip();
 			}
 		}, 1000 );
+		setTimeoutIds( ( timeoutIds ) => [ ...timeoutIds, oneSecId ] );
 	};
 
 	const waitFiveSecsThenHideTooltip = () => {
-		setTimeout( () => {
-			setDisplayTooltip( false );
+		const fiveSecId = setTimeout( () => {
+			finishDisplayingTooltip();
 		}, 5000 );
+		setTimeoutIds( ( timeoutIds ) => [ ...timeoutIds, fiveSecId ] );
 	};
 
 	useEffect( () => {
-		if ( tooltipDisplayedCount < tooltipDisplayedLimit ) {
+		if ( tooltipDisplayedCount < tooltipDisplayedLimit && tooltipDisplayedFullDuration < 1 ) {
 			waitOneSecThenDisplayTooltip();
 		}
 	}, [] );
+
+	useEffect( () => {
+		// Clear all timeouts when unmounting
+		return () => {
+			timeoutIds.forEach( ( id ) => {
+				clearTimeout( id );
+			} );
+		};
+	}, [ timeoutIds ] );
+
+	useEffect( () => {
+		if ( addingPreview ) {
+			finishDisplayingTooltip();
+		}
+	}, [ addingPreview ] );
 
 	return (
 		<div>

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -36,9 +36,11 @@ export const CustomTooltip = ( {
 				anchor={ anchorRef.current }
 				placement={ 'top' }
 				noArrow={ false }
+				offset={ 10 }
+				className="wikipediapreview-edit-tooltip-popover"
 			>
-				<div className="wikipediapreview-edit-inline-tooltip">
-					<p className="wikipediapreview-edit-inline-tooltip-text">{ __( 'Add Wikipedia Preview' ) }</p>
+				<div className="wikipediapreview-edit-tooltip-popover-content">
+					<p className="wikipediapreview-edit-tooltip-popover-text">{ __( 'Add Wikipedia Preview' ) }</p>
 				</div>
 			</Popover>
 		</div>

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
-export const incrementDisplayedCount = () => {
+export const incrementStoredDisplayedCount = () => {
 	fetch( '/wp-json/wikipediapreview/v1/option/', {
 		method: 'POST',
 		headers: {

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -28,12 +28,11 @@ export const CustomTooltip = ( {
 		updateStoredProperty( 'duration' );
 	};
 
-
 	const clearTimeouts = () => {
 		timeoutIds.forEach( ( id ) => {
 			clearTimeout( id );
 		} );
-	}
+	};
 
 	const waitOneSecThenDisplayTooltip = () => {
 		const oneSecId = setTimeout( () => {

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -11,7 +11,7 @@ export const CustomTooltip = ( {
 		setTimeout( () => {
 			setDisplayCustomTooltip( false );
 		}, 5000 );
-	}, [] );
+	} );
 
 	return (
 		<div>

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -1,33 +1,28 @@
 import { __ } from '@wordpress/i18n';
+import { Popover } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 
-export const CustomTooltip = () => {
-	const wikipediaPreviewToolbarButton = document.querySelector( '.wikipediapreview-edit-toolbar-button' );
-	const toolbarButtonRect = wikipediaPreviewToolbarButton?.getBoundingClientRect();
-
-	const computeTooltipPosition = ( targetRect ) => {
-        console.log('computeTooltipPosition...');
-        const targetCenterX = targetRect.left + targetRect.width / 2;
-        const targetCenterY = targetRect.top + targetRect.height / 2;
-
-
-        console.log('...top, left', targetCenterY, targetCenterX);
-
-        return {
-            top: targetCenterY,
-            left: targetCenterX,
-        };
-    }
+export const CustomTooltip = ( {
+	anchorRef,
+	setShowCustomTooltip,
+} ) => {
+	useEffect( () => {
+		setTimeout( () => {
+			setShowCustomTooltip( false );
+		}, 5000 );
+	}, [] );
 
 	return (
-		<div
-			className="wikipediapreview-edit-inline-tooltip"
-			style={
-				toolbarButtonRect
-					? computeTooltipPosition( toolbarButtonRect )
-					: {}
-			}
-		>
-			{ __( 'Add Wikipedia Preview', 'wikipedia-preview' ) }
+		<div>
+			<Popover
+				anchor={ anchorRef.current }
+				placement={ 'top' }
+				noArrow={ false }
+			>
+				<div className="wikipediapreview-edit-inline-tooltip">
+					<p className="wikipediapreview-edit-inline-tooltip-text">{ __( 'Add Wikipedia Preview' ) }</p>
+				</div>
+			</Popover>
 		</div>
 	);
 };

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -2,14 +2,31 @@ import { __ } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
+export const getDisplayedCount = ( setLocal ) => {
+	fetch( '/wp-json/wikipediapreview/v1/option/' )
+		.then( ( response ) => response.json() )
+		.then( ( value ) => {
+			setLocal( value );
+		} );
+};
+
+export const incrementDisplayedCount = () => {
+	fetch( '/wp-json/wikipediapreview/v1/option/', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+	} );
+};
+
 export const CustomTooltip = ( {
 	anchorRef,
-	setDisplayCustomTooltip,
+	setDisplayTooltip,
 } ) => {
 	useEffect( () => {
 		// Wait 5 seconds and then hide the tooltip
 		setTimeout( () => {
-			setDisplayCustomTooltip( false );
+			setDisplayTooltip( false );
 		}, 5000 );
 	} );
 

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -1,0 +1,25 @@
+import { __ } from '@wordpress/i18n';
+
+export const CustomTooltip = () => {
+    const wikipediaPreviewToolbarButton = document.querySelector( '.wikipediapreview-edit-toolbar-button' );
+    const toolbarButtonRect = wikipediaPreviewToolbarButton?.getBoundingClientRect();
+
+    // TODO computeTooltipPosition()
+    
+
+    return (
+        <div
+            className='wikipediapreview-edit-inline-tooltip'
+            style={
+                toolbarButtonRect
+                    ? {
+                        top: toolbarButtonRect.top,
+                        left: toolbarButtonRect.left,
+                    }
+                    : {}
+            }
+        >
+            { __( 'Add Wikipedia Preview', 'wikipedia-preview' ) }
+        </div>
+    );
+};

--- a/src/link/tooltip.js
+++ b/src/link/tooltip.js
@@ -1,25 +1,33 @@
 import { __ } from '@wordpress/i18n';
 
 export const CustomTooltip = () => {
-    const wikipediaPreviewToolbarButton = document.querySelector( '.wikipediapreview-edit-toolbar-button' );
-    const toolbarButtonRect = wikipediaPreviewToolbarButton?.getBoundingClientRect();
+	const wikipediaPreviewToolbarButton = document.querySelector( '.wikipediapreview-edit-toolbar-button' );
+	const toolbarButtonRect = wikipediaPreviewToolbarButton?.getBoundingClientRect();
 
-    // TODO computeTooltipPosition()
-    
+	const computeTooltipPosition = ( targetRect ) => {
+        console.log('computeTooltipPosition...');
+        const targetCenterX = targetRect.left + targetRect.width / 2;
+        const targetCenterY = targetRect.top + targetRect.height / 2;
 
-    return (
-        <div
-            className='wikipediapreview-edit-inline-tooltip'
-            style={
-                toolbarButtonRect
-                    ? {
-                        top: toolbarButtonRect.top,
-                        left: toolbarButtonRect.left,
-                    }
-                    : {}
-            }
-        >
-            { __( 'Add Wikipedia Preview', 'wikipedia-preview' ) }
-        </div>
-    );
+
+        console.log('...top, left', targetCenterY, targetCenterX);
+
+        return {
+            top: targetCenterY,
+            left: targetCenterX,
+        };
+    }
+
+	return (
+		<div
+			className="wikipediapreview-edit-inline-tooltip"
+			style={
+				toolbarButtonRect
+					? computeTooltipPosition( toolbarButtonRect )
+					: {}
+			}
+		>
+			{ __( 'Add Wikipedia Preview', 'wikipedia-preview' ) }
+		</div>
+	);
 };

--- a/tooltip.php
+++ b/tooltip.php
@@ -3,23 +3,29 @@
 DEFINE( 'WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT', 'wikipediapreview_tooltip_count' );
 
 function wikipediapreview_get_tooltip_count() {
-    return get_option( WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT, 0 );
+	return get_option(
+		WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT,
+		0
+	);
 }
 
 function wikipediapreview_increment_tooltip_count() {
-    $count = wikipediapreview_get_tooltip_count();
-    update_option( WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT, $count + 1 );
+	$count = wikipediapreview_get_tooltip_count();
+	update_option(
+		WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT,
+		$count + 1
+	);
 }
 
 add_action('rest_api_init', function () {
-    $route_namespace = 'wikipediapreview/v1';
+	$route_namespace = 'wikipediapreview/v1';
 
-    register_rest_route($route_namespace, '/option/', array(
-        'methods' => 'GET',
-        'callback' => 'wikipediapreview_get_tooltip_count',
-    ));
-    register_rest_route($route_namespace, '/option/', array(
-        'methods' => 'POST',
-        'callback' => 'wikipediapreview_increment_tooltip_count',
-    ));
+	register_rest_route( $route_namespace, '/option/', array(
+		'methods'  => 'GET',
+		'callback' => 'wikipediapreview_get_tooltip_count',
+	) );
+	register_rest_route( $route_namespace, '/option/', array(
+		'methods'  => 'POST',
+		'callback' => 'wikipediapreview_increment_tooltip_count',
+	) );
 });

--- a/tooltip.php
+++ b/tooltip.php
@@ -1,6 +1,7 @@
 <?php
 
 DEFINE( 'WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT', 'wikipediapreview_tooltip_count' );
+DEFINE( 'WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_DURATION', 'wikipediapreview_tooltip_duration' );
 
 function wikipediapreview_get_tooltip_count() {
 	return get_option(
@@ -17,13 +18,49 @@ function wikipediapreview_increment_tooltip_count() {
 	);
 }
 
+function wikipediapreview_update_tooltip_duration() {
+	update_option(
+		WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_DURATION,
+		1
+	);
+}
+
+// For debugging purposes
+function wikipediapreview_reset_tooltip_properties() {
+	update_option(
+		WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT,
+		0
+	);
+	update_option(
+		WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_DURATION,
+		0
+	);
+}
+
+
 function wikipediapreview_set_rest_endpoint() {
 	register_rest_route(
 		'wikipediapreview/v1',
-		'/option/',
+		'/count/',
 		array(
 			'methods'  => 'POST',
 			'callback' => 'wikipediapreview_increment_tooltip_count',
+		)
+	);
+	register_rest_route(
+		'wikipediapreview/v1',
+		'/duration/',
+		array(
+			'methods'  => 'POST',
+			'callback' => 'wikipediapreview_update_tooltip_duration',
+		)
+	);
+	register_rest_route(
+		'wikipediapreview/v1',
+		'/reset/',
+		array(
+			'methods'  => 'POST',
+			'callback' => 'wikipediapreview_reset_tooltip_properties',
 		)
 	);
 }
@@ -43,6 +80,7 @@ function wikipediapreview_tooltip_enqueue_script() {
 
 	$options = array(
 		'tooltipCount' => wikipediapreview_get_tooltip_count(),
+		'tooltipDuration' => get_option( WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_DURATION, 0 ),
 	);
 
 	wp_localize_script( 'wikipedia-preview-tooltip', 'wikipediapreviewCustomTooltip', $options );

--- a/tooltip.php
+++ b/tooltip.php
@@ -1,6 +1,16 @@
 <?php
 
+/*
+ * The number of times the tooltip has been displayed, whether in full duration or not.
+ * This count can be incremented until we hit a limit (set on the client side).
+ */
 DEFINE( 'WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT', 'wikipediapreview_tooltip_count' );
+
+/*
+ * Whether or not the tooltip has been displayed in full duration at least once,
+ * this acts as a boolean that's either 0 or 1. When set to 1, we infer the
+ * Wikipedia Preview plugin has been 'discovered' and hence we do not display it again
+ */
 DEFINE( 'WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_DURATION', 'wikipediapreview_tooltip_duration' );
 
 function wikipediapreview_get_tooltip_count() {

--- a/tooltip.php
+++ b/tooltip.php
@@ -35,7 +35,7 @@ function wikipediapreview_tooltip_enqueue_script() {
 
 	wp_enqueue_script(
 		'wikipedia-preview-tooltip',
-		$src_link_dir . 'edit.js',
+		$src_link_dir . 'tooltip.js',
 		$no_dependencies,
 		WIKIPEDIA_PREVIEW_PLUGIN_VERSION,
 		$in_footer

--- a/tooltip.php
+++ b/tooltip.php
@@ -79,7 +79,7 @@ function wikipediapreview_tooltip_enqueue_script() {
 	);
 
 	$options = array(
-		'tooltipCount' => wikipediapreview_get_tooltip_count(),
+		'tooltipCount'    => wikipediapreview_get_tooltip_count(),
 		'tooltipDuration' => get_option( WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_DURATION, 0 ),
 	);
 

--- a/tooltip.php
+++ b/tooltip.php
@@ -45,7 +45,7 @@ function wikipediapreview_tooltip_enqueue_script() {
 		'tooltipCount' => wikipediapreview_get_tooltip_count(),
 	);
 
-	wp_localize_script( 'wikipedia-preview-tooltip', 'wikipediapreview_custom_tooltip', $options );
+	wp_localize_script( 'wikipedia-preview-tooltip', 'wikipediapreviewCustomTooltip', $options );
 }
 
 add_action( 'enqueue_block_editor_assets', 'wikipediapreview_tooltip_enqueue_script' );

--- a/tooltip.php
+++ b/tooltip.php
@@ -1,0 +1,25 @@
+<?php
+
+DEFINE( 'WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT', 'wikipediapreview_tooltip_count' );
+
+function wikipediapreview_get_tooltip_count() {
+    return get_option( WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT, 0 );
+}
+
+function wikipediapreview_increment_tooltip_count() {
+    $count = wikipediapreview_get_tooltip_count();
+    update_option( WIKIPEDIA_PREVIEW_TOOLTIP_DISPLAYED_COUNT, $count + 1 );
+}
+
+add_action('rest_api_init', function () {
+    $route_namespace = 'wikipediapreview/v1';
+
+    register_rest_route($route_namespace, '/option/', array(
+        'methods' => 'GET',
+        'callback' => 'wikipediapreview_get_tooltip_count',
+    ));
+    register_rest_route($route_namespace, '/option/', array(
+        'methods' => 'POST',
+        'callback' => 'wikipediapreview_increment_tooltip_count',
+    ));
+});

--- a/tooltip.php
+++ b/tooltip.php
@@ -17,7 +17,7 @@ function wikipediapreview_increment_tooltip_count() {
 	);
 }
 
-add_action('rest_api_init', function () {
+function wikipediapreview_set_rest_endpoints() {
 	$route_namespace = 'wikipediapreview/v1';
 
 	register_rest_route( $route_namespace, '/option/', array(
@@ -28,4 +28,6 @@ add_action('rest_api_init', function () {
 		'methods'  => 'POST',
 		'callback' => 'wikipediapreview_increment_tooltip_count',
 	) );
-});
+}
+
+add_action( 'rest_api_init', 'wikipediapreview_set_rest_endpoints' );

--- a/tooltip.php
+++ b/tooltip.php
@@ -20,14 +20,22 @@ function wikipediapreview_increment_tooltip_count() {
 function wikipediapreview_set_rest_endpoints() {
 	$route_namespace = 'wikipediapreview/v1';
 
-	register_rest_route( $route_namespace, '/option/', array(
-		'methods'  => 'GET',
-		'callback' => 'wikipediapreview_get_tooltip_count',
-	) );
-	register_rest_route( $route_namespace, '/option/', array(
-		'methods'  => 'POST',
-		'callback' => 'wikipediapreview_increment_tooltip_count',
-	) );
+	register_rest_route(
+		$route_namespace,
+		'/option/',
+		array(
+			'methods'  => 'GET',
+			'callback' => 'wikipediapreview_get_tooltip_count',
+		)
+	);
+	register_rest_route(
+		$route_namespace,
+		'/option/',
+		array(
+			'methods'  => 'POST',
+			'callback' => 'wikipediapreview_increment_tooltip_count',
+		)
+	);
 }
 
 add_action( 'rest_api_init', 'wikipediapreview_set_rest_endpoints' );

--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -166,5 +166,6 @@ add_action( 'enqueue_block_editor_assets', 'wikipediapreview_guten_enqueue' );
 add_action( 'init', 'myguten_set_script_translations' );
 add_action( 'init', 'register_detectlinks_postmeta' );
 
+require __DIR__ . '/tooltip.php';
 require __DIR__ . '/banner.php';
 require __DIR__ . '/intro.php';


### PR DESCRIPTION
https://phabricator.wikimedia.org/T352298

Use the Wordpress `Popover` component to fabricate our custom tooltip