### PR TITLE
T363600: use a single Popover

### DIFF
--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -114,7 +114,7 @@ const Edit = ( {
 		}
 
 		return lastValueCount > valueCount;
-	}
+	};
 
 	const goToEdit = () => {
 		startAddingPreview();
@@ -176,21 +176,20 @@ const Edit = ( {
 		}
 	}, [ activeAttributes ] );
 
-    useEffect( () => {
-        valueRef.current = value;
+	useEffect( () => {
+		valueRef.current = value;
 
-        if ( removesPreviewFormat() ) {
-            const formatStart = getFormatStart( value.start - 1 );
-            const formatEnd = getFormatEnd( value.end + 1 );
-            onChange( removeFormat( value, formatType, formatStart, formatEnd ) );
-        }
+		if ( removesPreviewFormat() ) {
+			const formatStart = getFormatStart( value.start - 1 );
+			const formatEnd = getFormatEnd( value.end + 1 );
+			onChange( removeFormat( value, formatType, formatStart, formatEnd ) );
+		}
+	}, [ value.formats ] );
 
-    }, [ value.formats ] );
-
-    useEffect( () => {
+	useEffect( () => {
 		// Update lastValue with the previous value
-        setLastValue( valueRef.current );
-    }, [ value ] );
+		setLastValue( valueRef.current );
+	}, [ value ] );
 
 	return (
 		<>
@@ -210,7 +209,7 @@ const Edit = ( {
 				addingPreview={ addingPreview }
 			/>
 			{ ( addingPreview || viewingPreview ) && (
-				< WikipediaPreviewPopover
+				<WikipediaPreviewPopover
 					addingPreview={ addingPreview }
 					stopAddingPreview={ stopAddingPreview }
 					viewingPreview={ viewingPreview }
@@ -224,7 +223,7 @@ const Edit = ( {
 					contentRef={ contentRef }
 					settings={ settings }
 				/>
-			)}
+			) }
 		</>
 	);
 };

--- a/src/link/edit.js
+++ b/src/link/edit.js
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
-import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton, Popover } from '@wordpress/components';
 import {
 	create,
 	insert,
@@ -12,7 +12,6 @@ import { __ } from '@wordpress/i18n';
 import { InlineEditUI } from './inline';
 import { PreviewEditUI } from './preview';
 import { CustomTooltip } from './tooltip';
-import { Popover } from '@wordpress/components';
 
 const formatType = 'wikipediapreview/link';
 const formatTitle = __( 'Wikipedia Preview', 'wikipedia-preview' );
@@ -44,22 +43,9 @@ const Edit = ( {
 } ) => {
 	const [ addingPreview, setAddingPreview ] = useState( false );
 	const startAddingPreview = () => setAddingPreview( true );
-	// const startAddingPreview = () => {
-	// 	console.log('startAddingPreview');
-	// 	setAddingPreview( true );
-	// 	// if ( contentRef.current ) {
-	// 	// 	contentRef.current.focus();
-	// 	// }
-	// };
 	const stopAddingPreview = () => setAddingPreview( false );
 	const [ viewingPreview, setViewingPreview ] = useState( false );
 	const startViewingPreview = () => setViewingPreview( true );
-	// const startViewingPreview = () => {
-	// 	setViewingPreview( true );
-	// 	if ( contentRef.current ) {
-	// 		contentRef.current.focus();
-	// 	}
-	// };
 	const stopViewingPreview = () => setViewingPreview( false );
 	const [ lastValue, setLastValue ] = useState( null );
 	const toolbarButtonRef = useRef();
@@ -120,13 +106,8 @@ const Edit = ( {
 	};
 
 	const goToEdit = () => {
-		console.log('goToEdit - value:', value);
-		console.log('goToEdit - contentRef:', contentRef);
-		console.log('goToEdit - activeAttributes:', activeAttributes);
-		
 		startAddingPreview();
 		stopViewingPreview();
-		// onFocus();
 	};
 
 	const onClosePreview = () => {
@@ -182,7 +163,6 @@ const Edit = ( {
 	};
 
 	const handleTextEdit = () => {
-		console.log('handleTextEdit');
 		// Assuming a Left-To-Right language:
 		// --> cursorDirection > 0 means cursor is moving left
 		// --> cursorDirection < 0 means cursor is moving right
@@ -195,11 +175,11 @@ const Edit = ( {
 				: lastValue.formats[ value.end - 1 ] &&
 				lastValue.formats[ value.end - 1 ][ 0 ].type === formatType;
 
+		console.log('editDetected, involvesPreviewFormat', editDetected, involvesPreviewFormat);
 		if ( editDetected && involvesPreviewFormat ) {
 			const formatStart = getFormatStart( value.start - 1 );
 			const formatEnd = getFormatEnd( value.end + 1 );
 			onChange( removeFormat( value, formatType, formatStart, formatEnd ) );
-			// setLastValue( null );
 		}
 	};
 
@@ -220,11 +200,6 @@ const Edit = ( {
 			setLastValue( value );
 		}
 	}, [ value ] );
-
-	useEffect( () => {
-		console.log('edit.js - adding/viewing useEffect  addingPreview:', addingPreview);
-		console.log('edit.js - adding/viewing useEffect viewingPreview:', viewingPreview);
-	}, [ addingPreview, viewingPreview ] );
 
 	return (
 		<>

--- a/src/link/inline.js
+++ b/src/link/inline.js
@@ -1,10 +1,9 @@
 import {
-	Popover,
 	TextControl,
 	Button,
 	KeyboardShortcuts,
 } from '@wordpress/components';
-import { getTextContent, slice, useAnchor } from '@wordpress/rich-text';
+import { getTextContent, slice } from '@wordpress/rich-text';
 import { useState, useEffect, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getSiteLanguage, isTextNearTheEdge } from './utils';
@@ -12,9 +11,6 @@ import { prefixSearch, fulltextSearch, abortAllRequest } from './api';
 import { LanguageSelector } from './language-selector';
 
 export const InlineEditUI = ( {
-	contentRef,
-	settings,
-	onClose,
 	onApply,
 	value,
 	activeAttributes,
@@ -30,11 +26,6 @@ export const InlineEditUI = ( {
 	const inputRef = createRef();
 
 	let placement = 'top';
-	const anchor = useAnchor( {
-		editableContentElement: contentRef.current,
-		value,
-		settings,
-	} );
 
 	useEffect( () => {
 		setTitle( activeAttributes.title || getTextContent( slice( value ) ) );
@@ -72,19 +63,13 @@ export const InlineEditUI = ( {
 		}
 	}, [ lang ] );
 
-	if ( isTextNearTheEdge( anchor ) ) {
-		placement = 'right';
-	}
+	// TODO: move isTextNearTheEdge logic to parent
+	// if ( isTextNearTheEdge( anchor ) ) {
+	// 	placement = 'right';
+	// }
 
 	return (
-		<Popover
-			anchor={ anchor }
-			onClose={ onClose }
-			placement={ placement }
-			className="wikipediapreview-edit-inline"
-			noArrow={ false }
-			expandOnMobile={ true }
-		>
+		<div>
 			{ ! languageSelector ? (
 				<div>
 					<div className="wikipediapreview-edit-inline-search">
@@ -237,6 +222,6 @@ export const InlineEditUI = ( {
 					},
 				} }
 			/>
-		</Popover>
+		</div>
 	);
 };

--- a/src/link/inline.js
+++ b/src/link/inline.js
@@ -6,7 +6,7 @@ import {
 import { getTextContent, slice } from '@wordpress/rich-text';
 import { useState, useEffect, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { getSiteLanguage, isTextNearTheEdge } from './utils';
+import { getSiteLanguage } from './utils';
 import { prefixSearch, fulltextSearch, abortAllRequest } from './api';
 import { LanguageSelector } from './language-selector';
 
@@ -24,8 +24,6 @@ export const InlineEditUI = ( {
 	const [ focused, setFocused ] = useState( false );
 	const [ langCodeAdjustment, setLangCodeAdjustment ] = useState( false );
 	const inputRef = createRef();
-
-	let placement = 'top';
 
 	useEffect( () => {
 		setTitle( activeAttributes.title || getTextContent( slice( value ) ) );
@@ -62,11 +60,6 @@ export const InlineEditUI = ( {
 			setLangCodeAdjustment( false );
 		}
 	}, [ lang ] );
-
-	// TODO: move isTextNearTheEdge logic to parent
-	// if ( isTextNearTheEdge( anchor ) ) {
-	// 	placement = 'right';
-	// }
 
 	return (
 		<div>

--- a/src/link/popover.js
+++ b/src/link/popover.js
@@ -6,76 +6,75 @@ import { PreviewEditUI } from './preview';
 import { isTextNearTheEdge } from './utils';
 
 export const WikipediaPreviewPopover = ( {
-    addingPreview,
-    stopAddingPreview,
-    viewingPreview,
-    stopViewingPreview,
-    updateAttributes,
-    insertText,
-    removeAttributes,
-    goToEdit,
-    value,
-    activeAttributes,
-    contentRef,
-    settings,
+	addingPreview,
+	stopAddingPreview,
+	viewingPreview,
+	stopViewingPreview,
+	updateAttributes,
+	insertText,
+	removeAttributes,
+	goToEdit,
+	value,
+	activeAttributes,
+	contentRef,
+	settings,
 } ) => {
-    const anchor = useAnchor( {
+	const anchor = useAnchor( {
 		editableContentElement: contentRef.current,
 		value,
 		settings,
 	} );
 
-    const onClosePreview = () => {
+	const onClosePreview = () => {
 		if ( ! Object.keys( activeAttributes ).length ) {
 			stopViewingPreview();
 		}
 	};
 
-    const onClickPopoverOutside = useCallback( ( e ) => {
+	const onClickPopoverOutside = useCallback( ( e ) => {
 		if ( e.target.className === 'components-popover__content' ) {
 			stopViewingPreview();
 		}
 	}, [] );
 
-    const setPlacement = () => {
-        if ( isTextNearTheEdge( anchor ) ) {
-            return 'right';
-        } else if ( addingPreview ) {
-            return 'top';
-        } else {
-            return 'bottom';
-        }
-    };
+	const setPlacement = () => {
+		if ( isTextNearTheEdge( anchor ) ) {
+			return 'right';
+		} else if ( addingPreview ) {
+			return 'top';
+		}
+		return 'bottom';
+	};
 
-    return (
-        <Popover
-            anchor={ anchor }
-            placement={ setPlacement() }
-            noArrow={ false }
-            expandOnMobile={ true }
-            onClose={ addingPreview ? stopAddingPreview : onClosePreview }
-            className={`wikipediapreview-edit-${ addingPreview ? 'inline' : 'preview-popover' }`}
-            onClick={ onClickPopoverOutside }
-        >
-            { addingPreview && (
-                <InlineEditUI
-                    onApply={
-                        value.start !== value.end || activeAttributes.title
-                            ? updateAttributes
-                            : insertText
-                    }
-                    value={ value }
-                    activeAttributes={ activeAttributes }
-                />
-            ) }
-            { viewingPreview && (
-                <PreviewEditUI
-                    onEdit={ goToEdit }
-                    onRemove={ removeAttributes }
-                    onForceClose={ stopViewingPreview }
-                    activeAttributes={ activeAttributes }
-                />
-            ) }
-        </Popover>
-    );
+	return (
+		<Popover
+			anchor={ anchor }
+			placement={ setPlacement() }
+			noArrow={ false }
+			expandOnMobile={ true }
+			onClose={ addingPreview ? stopAddingPreview : onClosePreview }
+			className={ `wikipediapreview-edit-${ addingPreview ? 'inline' : 'preview-popover' }` }
+			onClick={ onClickPopoverOutside }
+		>
+			{ addingPreview && (
+				<InlineEditUI
+					onApply={
+						value.start !== value.end || activeAttributes.title
+							? updateAttributes
+							: insertText
+					}
+					value={ value }
+					activeAttributes={ activeAttributes }
+				/>
+			) }
+			{ viewingPreview && (
+				<PreviewEditUI
+					onEdit={ goToEdit }
+					onRemove={ removeAttributes }
+					onForceClose={ stopViewingPreview }
+					activeAttributes={ activeAttributes }
+				/>
+			) }
+		</Popover>
+	);
 };

--- a/src/link/popover.js
+++ b/src/link/popover.js
@@ -2,6 +2,7 @@ import { useAnchor } from '@wordpress/rich-text';
 import { Popover } from '@wordpress/components';
 import { InlineEditUI } from './inline';
 import { PreviewEditUI } from './preview';
+import { isTextNearTheEdge } from './utils';
 
 export const WikipediaPreviewPopover = ( {
     addingPreview,
@@ -29,10 +30,20 @@ export const WikipediaPreviewPopover = ( {
 		}
 	};
 
+    const setPlacement = () => {
+        if ( isTextNearTheEdge( anchor ) ) {
+            return 'right';
+        } else if ( addingPreview ) {
+            return 'top';
+        } else {
+            return 'bottom';
+        }
+    };
+
     return (
         <Popover
             anchor={ anchor }
-            placement={ addingPreview ? 'top' : 'bottom' }
+            placement={ setPlacement() }
             noArrow={ false }
             expandOnMobile={ true }
             onClose={ addingPreview ? stopAddingPreview : onClosePreview }

--- a/src/link/popover.js
+++ b/src/link/popover.js
@@ -1,0 +1,63 @@
+import { useAnchor } from '@wordpress/rich-text';
+import { Popover } from '@wordpress/components';
+import { InlineEditUI } from './inline';
+import { PreviewEditUI } from './preview';
+
+export const WikipediaPreviewPopover = ( {
+    addingPreview,
+    stopAddingPreview,
+    viewingPreview,
+    stopViewingPreview,
+    updateAttributes,
+    insertText,
+    removeAttributes,
+    goToEdit,
+    value,
+    activeAttributes,
+    contentRef,
+    settings,
+} ) => {
+    const anchor = useAnchor( {
+		editableContentElement: contentRef.current,
+		value,
+		settings,
+	} );
+
+    const onClosePreview = () => {
+		if ( ! Object.keys( activeAttributes ).length ) {
+			stopViewingPreview();
+		}
+	};
+
+    return (
+        <Popover
+            anchor={ anchor }
+            placement={ addingPreview ? 'top' : 'bottom' }
+            noArrow={ false }
+            expandOnMobile={ true }
+            onClose={ addingPreview ? stopAddingPreview : onClosePreview }
+            className={`wikipediapreview-edit-${ addingPreview ? 'inline' : 'preview-popover' }`}
+            // onClick={ onClickPopoverOutside }
+        >
+            { addingPreview && (
+                <InlineEditUI
+                    onApply={
+                        value.start !== value.end || activeAttributes.title
+                            ? updateAttributes
+                            : insertText
+                    }
+                    value={ value }
+                    activeAttributes={ activeAttributes }
+                />
+            ) }
+            { viewingPreview && (
+                <PreviewEditUI
+                    onEdit={ goToEdit }
+                    onRemove={ removeAttributes }
+                    onForceClose={ stopViewingPreview }
+                    activeAttributes={ activeAttributes }
+                />
+            ) }
+        </Popover>
+    );
+};

--- a/src/link/popover.js
+++ b/src/link/popover.js
@@ -1,3 +1,4 @@
+import { useCallback } from '@wordpress/element';
 import { useAnchor } from '@wordpress/rich-text';
 import { Popover } from '@wordpress/components';
 import { InlineEditUI } from './inline';
@@ -30,6 +31,12 @@ export const WikipediaPreviewPopover = ( {
 		}
 	};
 
+    const onClickPopoverOutside = useCallback( ( e ) => {
+		if ( e.target.className === 'components-popover__content' ) {
+			stopViewingPreview();
+		}
+	}, [] );
+
     const setPlacement = () => {
         if ( isTextNearTheEdge( anchor ) ) {
             return 'right';
@@ -48,7 +55,7 @@ export const WikipediaPreviewPopover = ( {
             expandOnMobile={ true }
             onClose={ addingPreview ? stopAddingPreview : onClosePreview }
             className={`wikipediapreview-edit-${ addingPreview ? 'inline' : 'preview-popover' }`}
-            // onClick={ onClickPopoverOutside }
+            onClick={ onClickPopoverOutside }
         >
             { addingPreview && (
                 <InlineEditUI

--- a/src/link/preview.js
+++ b/src/link/preview.js
@@ -2,7 +2,6 @@ import {
 	useState,
 	useEffect,
 	useLayoutEffect,
-	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import wikipediaPreview from 'wikipedia-preview';
@@ -15,11 +14,6 @@ export const PreviewEditUI = ( {
 } ) => {
 	const [ previewHtml, setPreviewHtml ] = useState( null );
 	const [ showControllersMenu, setShowControllersMenu ] = useState( true );
-	const onClickPopoverOutside = useCallback( ( e ) => {
-		if ( e.target.className === 'components-popover__content' ) {
-			onForceClose();
-		}
-	}, [] );
 	const toggleControllersMenu = () => {
 		/* eslint-disable-next-line no-shadow */
 		setShowControllersMenu( ( showControllersMenu ) => ! showControllersMenu );

--- a/src/link/preview.js
+++ b/src/link/preview.js
@@ -1,32 +1,20 @@
-import { Popover } from '@wordpress/components';
 import {
 	useState,
 	useEffect,
 	useLayoutEffect,
 	useCallback,
 } from '@wordpress/element';
-// import { useAnchor } from '@wordpress/rich-text';
 import { __ } from '@wordpress/i18n';
 import wikipediaPreview from 'wikipedia-preview';
-import { isTextNearTheEdge } from './utils';
 
 export const PreviewEditUI = ( {
-	// contentRef,
-	// settings,
-	// value,
 	activeAttributes,
 	onForceClose,
 	onEdit,
 	onRemove,
 } ) => {
-	let placement = 'bottom';
 	const [ previewHtml, setPreviewHtml ] = useState( null );
 	const [ showControllersMenu, setShowControllersMenu ] = useState( true );
-	// const anchor = useAnchor( {
-	// 	editableContentElement: contentRef.current,
-	// 	value,
-	// 	settings,
-	// } );
 	const onClickPopoverOutside = useCallback( ( e ) => {
 		if ( e.target.className === 'components-popover__content' ) {
 			onForceClose();
@@ -97,15 +85,6 @@ export const PreviewEditUI = ( {
 				?.removeEventListener( 'click', onForceClose );
 		};
 	}, [ previewHtml ] );
-
-	// TODO: move isTextNearTheEdge logic to parent
-	// if ( isTextNearTheEdge( anchor ) ) {
-	// 	placement = 'right';
-	// }
-
-	// useEffect( () => {
-	// 	console.log('preview.js - value:', value);
-	// }, [ value ]);
 
 	return (
 		<div className="wikipediapreview-edit-preview-container">

--- a/src/link/preview.js
+++ b/src/link/preview.js
@@ -5,17 +5,16 @@ import {
 	useLayoutEffect,
 	useCallback,
 } from '@wordpress/element';
-import { useAnchor } from '@wordpress/rich-text';
+// import { useAnchor } from '@wordpress/rich-text';
 import { __ } from '@wordpress/i18n';
 import wikipediaPreview from 'wikipedia-preview';
 import { isTextNearTheEdge } from './utils';
 
 export const PreviewEditUI = ( {
-	contentRef,
-	settings,
-	value,
+	// contentRef,
+	// settings,
+	// value,
 	activeAttributes,
-	onClose,
 	onForceClose,
 	onEdit,
 	onRemove,
@@ -23,11 +22,11 @@ export const PreviewEditUI = ( {
 	let placement = 'bottom';
 	const [ previewHtml, setPreviewHtml ] = useState( null );
 	const [ showControllersMenu, setShowControllersMenu ] = useState( true );
-	const anchor = useAnchor( {
-		editableContentElement: contentRef.current,
-		value,
-		settings,
-	} );
+	// const anchor = useAnchor( {
+	// 	editableContentElement: contentRef.current,
+	// 	value,
+	// 	settings,
+	// } );
 	const onClickPopoverOutside = useCallback( ( e ) => {
 		if ( e.target.className === 'components-popover__content' ) {
 			onForceClose();
@@ -99,31 +98,24 @@ export const PreviewEditUI = ( {
 		};
 	}, [ previewHtml ] );
 
-	if ( isTextNearTheEdge( anchor ) ) {
-		placement = 'right';
-	}
+	// TODO: move isTextNearTheEdge logic to parent
+	// if ( isTextNearTheEdge( anchor ) ) {
+	// 	placement = 'right';
+	// }
+
+	// useEffect( () => {
+	// 	console.log('preview.js - value:', value);
+	// }, [ value ]);
 
 	return (
-		<div>
-			<Popover
-				anchor={ anchor }
-				onClose={ onClose }
-				placement={ placement }
-				noArrow={ false }
-				expandOnMobile={ true }
-				className="wikipediapreview-edit-preview-popover"
-				onClick={ onClickPopoverOutside }
-			>
-				<div className="wikipediapreview-edit-preview-container">
-					<div
-						className="wikipediapreview-edit-preview"
-						dangerouslySetInnerHTML={ { __html: previewHtml } }
-					></div>
-					{ previewHtml && showControllersMenu && (
-						<ControllerEditUI onEdit={ onEdit } onRemove={ onRemove } />
-					) }
-				</div>
-			</Popover>
+		<div className="wikipediapreview-edit-preview-container">
+			<div
+				className="wikipediapreview-edit-preview"
+				dangerouslySetInnerHTML={ { __html: previewHtml } }
+			></div>
+			{ previewHtml && showControllersMenu && (
+				<ControllerEditUI onEdit={ onEdit } onRemove={ onRemove } />
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
https://phabricator.wikimedia.org/T363600

Currently we use the Wordpress `Popover` component in a couple of places: one for `PreviewEditUI` and one for `InlineEditUI`. The bug described in phab above is about the `Popover` not landing correctly to its `anchor` when rapidly switching between `PreviewEditUI` and `InlineEditUI` states. To fix this, I'm proposing refactoring our code to use only a single `Popover` for both states in a new `WikipediaPreviewPopover` component to render the different contents according to the current state. 

While refactoring, I ran into stale closure issues regarding our logic to detect and remove preview formats as the user edits the text. You will notice this by the replacement of `handleTextEdit` with `RemovesPreviewFormat`, for example. Overall, please do lots of regression test for both desktop and mobile