### PR TITLE
T345056: Update popover arrow style when dark mode is detected

### DIFF
--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -339,6 +339,18 @@ body {
 			box-shadow: none;
 		}
 
+		@media (prefers-color-scheme: dark ) {
+			.components-popover__arrow {
+				&::before {
+					background-color: unset;
+				}
+			}
+	
+			.components-popover__triangle-bg {
+				fill: #202122;
+			}
+		}
+
 		.wikipediapreview-edit-preview {
 			width: 350px;
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T345056#9647116

The preview popover content renders in dark mode (when user setting is detected) because all of that styling comes from the core library. However the actual popover arrow is decoupled from the core library, so we can just style the arrow separately. 

I have added this PR link to https://phabricator.wikimedia.org/T345056#9647116


<img width="300" alt="image" src="https://github.com/wikimedia/wikipediapreview-wordpress/assets/4752599/7ff6d433-2d7f-4f6e-af78-dd8b1742cb97">
<img width="300" alt="image" src="https://github.com/wikimedia/wikipediapreview-wordpress/assets/4752599/3b570117-7a42-4dd1-9582-254b0f3e46af">
