### PR TITLE
T360286: Remove onMouseEnter to fix conflict with keyboard navigation

### DIFF
--- a/src/link/sections.js
+++ b/src/link/sections.js
@@ -106,7 +106,6 @@ export const Sections = ( {
 								onKeyUp={ () => {
 									selectSection( item.id );
 								} }
-								onMouseEnter={ () => setHoverIndex( -1 ) }
 							>
 								<div className={ `${ sectionsPrefix }-list-item-content` }>
 									<span className={ `${ sectionsPrefix }-list-item-content-title` }>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T360286

This fixes the keyboard navigation bug that Sudhanshu found, testing well for me