### PR TITLE
T369636 Remove min-height and use default height from wordpress popover

### DIFF
--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -357,7 +357,6 @@ body {
 
 		.wikipediapreview-edit-preview {
 			width: 350px;
-			min-height: 214px;
 
 			&-container {
 				display: flex;

--- a/src/link/style.scss
+++ b/src/link/style.scss
@@ -424,6 +424,7 @@ body {
 
 			.wikipediapreview {
 				box-shadow: none;
+				min-height: 214px;
 
 				.wikipediapreview-footer {
 					position: relative;


### PR DESCRIPTION
Phabricator: https://phabricator.wikimedia.org/T369636

Before
<img width="481" alt="Screenshot 2024-08-16 at 10 52 54" src="https://github.com/user-attachments/assets/7628f5a6-8e65-4fe6-89fb-35cab8cc6c64">

After
<img width="497" alt="image" src="https://github.com/user-attachments/assets/920e40bf-f4a7-4ca9-bb04-11c7fcc0e6c8">

After some testing in dark mode and some more tweaking:
<img width="469" alt="Screenshot 2024-10-29 at 1 21 32 PM" src="https://github.com/user-attachments/assets/bef386ee-ec2e-48e7-bccc-64e8c5cffec9">

