### PR TITLE
Set node version to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '23.1'
+          node-version: 'latest'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This reverts node version back to latest in main workflow file, once the [Webpack issue](https://github.com/webpack/webpack/issues/18963) is resolved. 

Context: https://github.com/wikimedia/wikipediapreview-wordpress/pull/135