### PR TITLE
Adjust PluginDocumentSettingsPanel usage for WP 6.6+ compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wikipediapreview-wordpress",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wikipediapreview-wordpress",
-      "version": "1.14.3",
+      "version": "1.15.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikipediapreview-wordpress",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "WordPress plugin for Wikipedia Preview",
   "main": "init.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wikimediafoundation
 Donate link: https://donate.wikimedia.org/wiki/Ways_to_Give
 Tags: wikipedia, facts, popup, card, wiki
 Stable tag: 1.14.3
-Tested up to: 6.7.1
+Tested up to: 6.7.2
 License: MIT
 License URI: https://github.com/wikimedia/wikipedia-preview/blob/main/LICENSE
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wikimediafoundation
 Donate link: https://donate.wikimedia.org/wiki/Ways_to_Give
 Tags: wikipedia, facts, popup, card, wiki
-Stable tag: 1.14.3
+Stable tag: 1.15.0
 Tested up to: 6.7.2
 License: MIT
 License URI: https://github.com/wikimedia/wikipedia-preview/blob/main/LICENSE

--- a/src/postmeta/wp-postmeta-detectlinks.js
+++ b/src/postmeta/wp-postmeta-detectlinks.js
@@ -12,6 +12,7 @@ const WikipediaPreviewPostMetaDetectLinks = ( { postMeta, setPostMeta } ) => {
 	}
 	return (
 		<PluginDocumentSettingPanel
+			name="wikipedia-preview"
 			title={ __( 'Wikipedia Preview', 'wikipedia-preview' ) }
 			initialOpen="false"
 		>

--- a/src/postmeta/wp-postmeta-detectlinks.js
+++ b/src/postmeta/wp-postmeta-detectlinks.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { ToggleControl, PanelRow } from '@wordpress/components';
 
 const WikipediaPreviewPostMetaDetectLinks = ( { postMeta, setPostMeta } ) => {

--- a/wikipediapreview.php
+++ b/wikipediapreview.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/wikimedia/wikipedia-preview
  * Description: Provide context to your readers by displaying a Wikipedia article preview when a reader clicks or hovers over a word or concept.
  * Text Domain: wikipedia-preview
- * Version: 1.14.3
+ * Version: 1.15.0
  * Requires at least: 6.1
  * Requires PHP: 5.6.39
  * Author: Wikimedia Foundation
@@ -13,7 +13,7 @@
  * License URI: https://github.com/wikimedia/wikipedia-preview/blob/main/LICENSE
  */
 
-DEFINE( 'WIKIPEDIA_PREVIEW_PLUGIN_VERSION', '1.14.3' );
+DEFINE( 'WIKIPEDIA_PREVIEW_PLUGIN_VERSION', '1.15.0' );
 
 function get_public_post_types() {
 	$post_types        = get_post_types( array(), 'objects' );


### PR DESCRIPTION
This PR silences two errors we have encountered while using this plugin on recent WordPress sites

- The import source for the SlotFill component has changed from `@wordpress/edit-post` to `@wordpress/editor`
- The SlotFill component requires the name property

When the SCRIPT_DEBUG constant is set, both of these issues cause a console warning. In future versions of WordPress, it may break outright.